### PR TITLE
Add Sustainability Summer Camp content

### DIFF
--- a/content/sustainability_lab/Day-1/00_getting_started.md
+++ b/content/sustainability_lab/Day-1/00_getting_started.md
@@ -8,6 +8,17 @@ tags: ["minecraft", "sustainability", "day1"]
 
 Begin with an **orientation tour** of an existing sustainable village. Pick a sustainable energy source, teleport to a biome, and see how students before you built their towns. New arrivals get this tour on their first day so they can join ongoing builds.
 
+### Community Village Setup
+
+Start recording the basics of your settlement:
+
+- **Village name and biome**
+- **Nether station coordinates**
+- **Disaster you fled and the animal companion that came with you**
+- **Ideas for floating homes or other evolved dwellings**
+
+Keep these details handy—they will guide the tasks on later days.
+
 ## Next Steps
 
 ➡️ [Next: Choose Your Animal](/sustainability_lab/Day-1/01_choose_animal)

--- a/content/sustainability_lab/Day-1/00_getting_started.md
+++ b/content/sustainability_lab/Day-1/00_getting_started.md
@@ -4,6 +4,8 @@ tags: ["minecraft", "sustainability", "day1"]
 ---
 # Sustainability Lab: Day 1 – Getting Started
 
+**"E" is for Empathize.** Students are immersed in the StoryWorld of *Sam the Enderman*—a dimension ravaged by climate change. Jump into creative mode and build a shelter for your EARTH Knight protagonist and their special animal companion who have fled a disaster. This opening activity teaches empathy for the hero you'll guide through the rest of camp.
+
 Begin with an **orientation tour** of an existing sustainable village. Pick a sustainable energy source, teleport to a biome, and see how students before you built their towns. New arrivals get this tour on their first day so they can join ongoing builds.
 
 ## Next Steps

--- a/content/sustainability_lab/Day-1/02_choose_disaster.md
+++ b/content/sustainability_lab/Day-1/02_choose_disaster.md
@@ -4,7 +4,7 @@ tags: ["minecraft", "sustainability", "day1"]
 ---
 # Choose a Natural Disaster
 
-Decide which disaster your village must prepare for: tornado, tsunami, earthquake, or flood.
+Decide which disaster your village must prepare for: tornado, tsunami, earthquake, or flood. Pick a location where you'll take shelter and note the `/tp` coordinates so you can return quickly.
 
 ## Next Steps
 

--- a/content/sustainability_lab/Day-2/00_intro.md
+++ b/content/sustainability_lab/Day-2/00_intro.md
@@ -5,6 +5,8 @@ tags: ["minecraft", "sustainability", "day2"]
 
 # Sustainability Lab: Day 2 – Disaster Preparation
 
+**"A" is for Adventure.** Use a short window in creative mode to build a bunker before switching to adventure mode. Can you survive a new disaster—or even a zombie invasion? Bunker creation introduces life skills like hydration, nutrition, and self-defense.
+
 Make sure all Day 1 tasks are green on your board. Today we prepare for natural disasters and plan a sustainable power source.
 
 Choose **one** of the disasters to prepare for:

--- a/content/sustainability_lab/Day-2/00_intro.md
+++ b/content/sustainability_lab/Day-2/00_intro.md
@@ -7,7 +7,9 @@ tags: ["minecraft", "sustainability", "day2"]
 
 **"A" is for Adventure.** Use a short window in creative mode to build a bunker before switching to adventure mode. Can you survive a new disaster—or even a zombie invasion? Bunker creation introduces life skills like hydration, nutrition, and self-defense.
 
-Make sure all Day 1 tasks are green on your board. Today we prepare for natural disasters and plan a sustainable power source.
+Make sure all Day 1 tasks are green on your board. Once your instructor checks them off, clear yesterday's board and start fresh. Today we prepare for natural disasters and plan a sustainable power source.
+
+Sketch a bunker—or even a full escape room—to ride out future calamities. Think about community defenses and how you'll keep order if danger strikes.
 
 Confirm **one** of the disasters to prepare for:
 

--- a/content/sustainability_lab/Day-2/00_intro.md
+++ b/content/sustainability_lab/Day-2/00_intro.md
@@ -9,7 +9,7 @@ tags: ["minecraft", "sustainability", "day2"]
 
 Make sure all Day 1 tasks are green on your board. Today we prepare for natural disasters and plan a sustainable power source.
 
-Choose **one** of the disasters to prepare for:
+Confirm **one** of the disasters to prepare for:
 
 - 🌪️ [Tornado Prep](/sustainability_lab/Day-2/01_tornado)
 - 🌊 [Tsunami Prep](/sustainability_lab/Day-2/02_tsunami)

--- a/content/sustainability_lab/Day-2/01_tornado.md
+++ b/content/sustainability_lab/Day-2/01_tornado.md
@@ -1,5 +1,5 @@
 ---
-title: "2 - Tornado Prep"
+title: "Tornado Prep"
 tags: ["minecraft", "sustainability", "day2"]
 ---
 # Prepare for Tornadoes

--- a/content/sustainability_lab/Day-2/02_tsunami.md
+++ b/content/sustainability_lab/Day-2/02_tsunami.md
@@ -1,5 +1,5 @@
 ---
-title: "3 - Tsunami Prep"
+title: "Tsunami Prep"
 tags: ["minecraft", "sustainability", "day2"]
 ---
 # Prepare for Tsunamis

--- a/content/sustainability_lab/Day-2/03_earthquake.md
+++ b/content/sustainability_lab/Day-2/03_earthquake.md
@@ -1,5 +1,5 @@
 ---
-title: "4 - Earthquake Prep"
+title: "Earthquake Prep"
 tags: ["minecraft", "sustainability", "day2"]
 ---
 # Prepare for Earthquakes

--- a/content/sustainability_lab/Day-2/04_flood.md
+++ b/content/sustainability_lab/Day-2/04_flood.md
@@ -1,5 +1,5 @@
 ---
-title: "5 - Flood Prep"
+title: "Flood Prep"
 tags: ["minecraft", "sustainability", "day2"]
 ---
 # Prepare for Floods

--- a/content/sustainability_lab/Day-3/00_intro.md
+++ b/content/sustainability_lab/Day-3/00_intro.md
@@ -16,7 +16,7 @@ Sketch how you'll represent your power source in Minecraft. Will you build spinn
 - ☀️ [Solar Power](/sustainability_lab/Day-3/02_solar)
 - 🌬️ [Wind Power](/sustainability_lab/Day-3/03_wind)
 - 🌊 [Hydropower](/sustainability_lab/Day-3/04_hydro)
-- 🌊🌊 [Tidal Power](/sustainability_lab/Day-3/08_tidal)
+- 🐋 [Tidal Power](/sustainability_lab/Day-3/08_tidal)
 - 🌱 [Biomass](/sustainability_lab/Day-3/05_biomass)
 - 🌋 [Geothermal](/sustainability_lab/Day-3/06_geothermal)
 - ⚛️ [Nuclear Power](/sustainability_lab/Day-3/07_nuclear)

--- a/content/sustainability_lab/Day-3/00_intro.md
+++ b/content/sustainability_lab/Day-3/00_intro.md
@@ -5,6 +5,8 @@ tags: ["minecraft", "sustainability", "day3"]
 
 # Sustainability Lab: Day 3 – Sustainable Energy
 
+**"R" is for Renewables.** After the chaos of Day 2, return to creative mode to engineer a renewable energy system. Whether decorative builds or functioning redstone circuits, you'll explore numeracy, logic, and the physics of power generation.
+
 Move beyond redstone torches and create a new power source for your village. Solar arrays, windmills, or anything creative is welcome.
 
 Sketch how you'll represent your power source in Minecraft. Will you build spinning wind turbines or solar panels that light up with redstone?

--- a/content/sustainability_lab/Day-3/00_intro.md
+++ b/content/sustainability_lab/Day-3/00_intro.md
@@ -7,7 +7,7 @@ tags: ["minecraft", "sustainability", "day3"]
 
 **"R" is for Renewables.** After the chaos of Day 2, return to creative mode to engineer a renewable energy system. Whether decorative builds or functioning redstone circuits, you'll explore numeracy, logic, and the physics of power generation.
 
-Move beyond redstone torches and create a new power source for your village. Solar arrays, windmills, or anything creative is welcome.
+Move beyond redstone torches and create a new power source for your village. Solar arrays, windmills, or anything creative is welcome. Your main system might be a sci-fi hybrid thermal generator with tidal backup—or any renewable combo you dream up.
 
 Sketch how you'll represent your power source in Minecraft. Will you build spinning wind turbines or solar panels that light up with redstone?
 

--- a/content/sustainability_lab/Day-3/08_tidal.md
+++ b/content/sustainability_lab/Day-3/08_tidal.md
@@ -3,14 +3,13 @@ title: "Tidal Power"
 tags: ["minecraft", "sustainability", "day3", "energy"]
 ---
 
-# Tidal Power 🌊🌊
+# Tidal Power 🐋
 
 Tidal energy harnesses the rise and fall of ocean tides to generate electricity. In Minecraft, you can simulate tidal power with alternating water levels and redstone machines.
 
 ## Build Ideas
 - Build a piston-driven gate that opens and closes with the tide
-- Use sensors or timers to mimic rising and falling water
-- Create decorative underwater turbines or water wheels
+- Create underwater turbines or water wheels
 
 ## Real-World Connection
 Tidal power is a predictable form of sustainable energy that works best in coastal areas with strong tidal currents.

--- a/content/sustainability_lab/Day-4/00_market.md
+++ b/content/sustainability_lab/Day-4/00_market.md
@@ -4,6 +4,8 @@ tags: ["minecraft", "sustainability", "day4"]
 ---
 # Build a Market
 
+**"T" is for Trade Fair.** Design banners to represent your sustainable village and trade goods or prosocial services with fellow players. You can even explore youth justice themes while discovering "Doughnut Economics"—a sprinkle doughnut seeking balance between the ecological ceiling and social equity.
+
 Create a shop or market for your village. Use banners and signs with colorful designs (avoid black and white) to explain what you sell. Establish exchange rates like trading food for gold, and showcase your shop in the shared market world.
 
 ## Next Steps

--- a/content/sustainability_lab/Day-4/00_market.md
+++ b/content/sustainability_lab/Day-4/00_market.md
@@ -6,7 +6,9 @@ tags: ["minecraft", "sustainability", "day4"]
 
 **"T" is for Trade Fair.** Design banners to represent your sustainable village and trade goods or prosocial services with fellow players. You can even explore youth justice themes while discovering "Doughnut Economics"—a sprinkle doughnut seeking balance between the ecological ceiling and social equity.
 
-Create a shop or market for your village. Use banners and signs with colorful designs (avoid black and white) to explain what you sell. Establish exchange rates like trading food for gold, and showcase your shop in the shared market world.
+Create a shop or market for your village. Use banners and signs with colorful designs (avoid black and white) to explain what you sell. Try complementary colors from the wheel when designing your flag or banner. Establish exchange rates like trading food for gold, and showcase your shop in the shared market world.
+
+Ready for more flair? Host a sustainable fashion show in the Nether or End where skin designers strut their creations down a "catwalk".
 
 ## Next Steps
 

--- a/content/sustainability_lab/Day-5/00_government.md
+++ b/content/sustainability_lab/Day-5/00_government.md
@@ -6,6 +6,8 @@ tags: ["minecraft", "sustainability", "day5"]
 
 Your village needs rules. Discuss options like **consensus**, **monarchy**, **majority rule**, or **anarchy**.
 
+Also decide if you'll be **nomadic or stationary**, whether immigration is open or closed, and what skills newcomers must demonstrate. Plan how youth justice works—punishment, restorative practices, or a mix. Finally, list what you import and export and how those goods travel.
+
 ## Next Steps
 
 ➡️ [Next: Voting Mini-Game](/sustainability_lab/Day-5/01_voting)

--- a/content/sustainability_lab/Day-5/02_write_laws.md
+++ b/content/sustainability_lab/Day-5/02_write_laws.md
@@ -9,4 +9,4 @@ Record proposed laws in a book and discuss them with classmates. Decide which ru
 ## Next Steps
 
 ⬅️ [Back: Voting Mini-Game](/sustainability_lab/Day-5/01_voting)
-➡️ [Next: Ongoing Challenges](/sustainability_lab/Day-6/00_ongoing_challenges)
+➡️ [Next: Movie Knight](/sustainability_lab/Day-5/03_movie_knight)

--- a/content/sustainability_lab/Day-5/03_movie_knight.md
+++ b/content/sustainability_lab/Day-5/03_movie_knight.md
@@ -1,0 +1,12 @@
+---
+title: "4 - Movie Knight"
+tags: ["minecraft", "sustainability", "day5"]
+---
+# Movie Knight
+
+Celebrate your week of learning! Review the highlights of each day through storyboarded scenes that automatically fill your certificate of learning. Then hit the dance floor—both in Minecraft and in real life—to mark the end of the Sustainability Summer Camp.
+
+## Next Steps
+
+⬅️ [Back: Write the Laws](/sustainability_lab/Day-5/02_write_laws)
+➡️ [Next: Ongoing Challenges](/sustainability_lab/Day-6/00_ongoing_challenges)

--- a/content/sustainability_lab/Day-5/index.md
+++ b/content/sustainability_lab/Day-5/index.md
@@ -1,3 +1,7 @@
 ---
-title: Day 5
+title: "Day 5 – Highlight"
 ---
+
+## "H" is for Highlight!
+
+The cinematic journey of the learner as protagonist culminates with **MOVIE KNIGHT**. Revisit the past four days through storyboarded "movie moments" that automatically populate your certificate of learning. Celebrate your achievements on the dance floor—both virtually and in real life.

--- a/content/sustainability_lab/Day-6/00_ongoing_challenges.md
+++ b/content/sustainability_lab/Day-6/00_ongoing_challenges.md
@@ -4,7 +4,17 @@ tags: ["minecraft", "sustainability", "day6"]
 ---
 # Day 6+ – Ongoing Challenges
 
-Keep the momentum going by creating new tasks or pulling ideas from a shared board. Build libraries, pirate ships, rocket ships—anything that expands your world.
+Keep the momentum going by creating new tasks or pulling ideas from a shared board. Build libraries, pirate ships, rocket ships—anything that expands your world. Encourage classmates to post optional challenges like roller coasters, mini games, or Olympic-style events. The goal is a student-driven community that keeps growing after day five.
+
+Consider adding community traditions:
+
+- Choose a **Flower of the Realm** to represent your home.
+- Write an **anthem** and note the musical key.
+- Decide if education is a **standardized** curriculum or **mentor system**.
+- Choreograph a **dance of the Community Village**.
+- Plan a **regenerative soil** strategy for farming.
+- Establish **sustainable water and waste** systems.
+- Draft protocols for **welcoming foreign dignitaries**.
 
 ## Next Steps
 

--- a/content/sustainability_lab/Day-6/02_youth_justice.md
+++ b/content/sustainability_lab/Day-6/02_youth_justice.md
@@ -4,7 +4,7 @@ tags: ["minecraft", "sustainability", "day6"]
 ---
 # Youth Justice
 
-Explore how young villagers could be treated differently from adults. Design restorative practices rather than punitive ones.
+Explore how young villagers could be treated differently from adults. Decide whether youth receive the same punishment as adults or if you lean toward restorative justice. You can even choose a blend—for example, 90% punishment and 10% restorative work.
 
 ## Next Steps
 

--- a/content/sustainability_lab/index.md
+++ b/content/sustainability_lab/index.md
@@ -5,6 +5,8 @@ tags: ["minecraft", "beginner", "sustainability", "contents"]
 
 Welcome to the **Sustainability Lab**, a hands-on series of Minecraft challenges focused on sustainable energy and collaborative play. The course begins with an orientation tour of an existing sustainable village. You'll pick a sustainable energy source, teleport to a biome, and choose a special animal to join your adventure.
 
+The **Sustainability Summer Camp** is a five‑day journey where each day highlights a letter from **EARTH**. Ready to begin your adventure as an EARTH Knight through the lens of sustainability? Let's get started!
+
 - [Day 1](./sustainability_lab/Day-1/00_getting_started) – Getting Started
 - [Day 2](./sustainability_lab/Day-2/00_intro) – Disaster Prep
 - [Day 3](./sustainability_lab/Day-3/00_intro) – Sustainable Energy

--- a/content/sustainability_lab/index.md
+++ b/content/sustainability_lab/index.md
@@ -7,11 +7,34 @@ Welcome to the **Sustainability Lab**, a hands-on series of Minecraft challenges
 
 The **Sustainability Summer Camp** is a five‑day journey where each day highlights a letter from **EARTH**. Ready to begin your adventure as an EARTH Knight through the lens of sustainability? Let's get started!
 
-- [Day 1](./sustainability_lab/Day-1/00_getting_started) – Getting Started
-- [Day 2](./sustainability_lab/Day-2/00_intro) – Disaster Prep
-- [Day 3](./sustainability_lab/Day-3/00_intro) – Sustainable Energy
-- [Day 4](./sustainability_lab/Day-4/00_market) – Market Day
-- [Day 5](./sustainability_lab/Day-5/00_government) – Community Government
-- [Day 6+](./sustainability_lab/Day-6/00_ongoing_challenges) – Ongoing Challenges
+### 🌱 The E.A.R.T.H. Journey
+
+Step into the role of an **E.A.R.T.H. Knight** and explore a Minecraft world shaped by story, sustainability, and collective action. Each day blends storytelling, survival, creativity, and celebration. Click below to jump into each immersive experience:
+
+* [**Day 1 – E is for Empathize: Getting Started**](./sustainability_lab/Day-1/00_getting_started)
+  Meet *Sam the Enderman* in a climate cautionary tale. Then, in Creative Mode, build a shelter for your Knight and animal companion — both fleeing a disaster. Begin your quest by practicing empathy through story.
+
+* [**Day 2 – A is for Adventure: Disaster Prep**](./sustainability_lab/Day-2/00_intro)
+  Enter Adventure Mode and prepare for survival! Construct a bunker focused on hydration, nutrition, and protection. Navigate a new challenge and test your real-life skills in a Minecraft emergency.
+
+* [**Day 3 – R is for Renewables: Sustainable Energy**](./sustainability_lab/Day-3/00_intro)
+  Use Creative Mode to build clean energy systems with Redstone or decorative elements. Design with purpose as you explore the logic and justice behind renewable power.
+
+* [**Day 4 – T is for Trade Fair: Market Day**](./sustainability_lab/Day-4/00_market)
+  Join a village marketplace where trading, banners, and fair exchanges take center stage. Discover how Doughnut Economics helps balance social equity and ecological limits.
+
+* [**Day 5 – H is for Highlight: Community Government**](./sustainability_lab/Day-5/00_government)
+  Celebrate your week of learning! Create a storyboard of your adventure and earn a personal certificate. Reflect, dance, and share in the joy of community-led sustainability.
+
+* [**Day 6+ – Ongoing Challenges**](./sustainability_lab/Day-6/00_ongoing_challenges)
+  Ready for more? Take on bonus missions in storytelling, youth justice, language, and Indigenous knowledge. Keep your world growing and become a mentor for future EARTH Knights.
+
+
+You’ll take on the mantle of an **EARTH Knight**, learning to listen, build, and lead in community.
+
 
 Beyond these core days, additional classes dive into storytelling, languages, youth justice, and real-world sustainability topics. Use them to expand your Minecraft world and connect with other students in future adventures.
+
+We believe learning should be inclusive, joyful, and co-created. Extra missions explore stories, languages, climate justice, and Indigenous ways of knowing — giving you the chance to expand your Minecraft world and become a mentor to others.
+
+Let’s build a future where kindness, creativity, and equity guide the game. 🌱


### PR DESCRIPTION
## Summary
- add EARTH-themed summer camp description
- expand day overviews with Empathize, Adventure, Renewables, Trade Fair, and Highlight
- introduce Movie Knight page and updated navigation links

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ba0bdeb8832b8481e48f356bad22