### PR TITLE
Fix home icon path

### DIFF
--- a/quartz/components/PageTitle.tsx
+++ b/quartz/components/PageTitle.tsx
@@ -9,7 +9,7 @@ const PageTitle: QuartzComponent = ({ fileData, cfg, displayClass }: QuartzCompo
   return (
     <h2 class={classNames(displayClass, "page-title")}>
       <a href={baseDir} class="page-title-link">
-        <img src="/images/icon.png" alt="Home Icon" class="page-title-icon" />
+        <img src={`${baseDir}/static/icon.png`} alt="Home Icon" class="page-title-icon" />
         <span class="page-title-text">{title}</span>
       </a>
     </h2>


### PR DESCRIPTION
## Summary
- ensure PageTitle icon uses relative path based on current page

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run lint` *(fails: missing script)*
- `npm run build` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b48af0004832bac474d9f4c512b52