### PR TITLE
Add image compression to build workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -47,11 +47,21 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: 22 }
 
-      - name: Install dependencies
+      - name: Install Node dependencies
         run: npm ci
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: pip install .
 
       - name: Build Quartz
         run: npx quartz build
+
+      - name: Compress images
+        run: python build.py
 
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v3
@@ -66,7 +76,7 @@ jobs:
       id-token: write
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}  # supported by the action :contentReference[oaicite:1]{index=1}
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ This repo uses **GitHub Actions** to auto-deploy Quartz to GitHub Pages whenever
 Found in `.github/workflows/jekyll-gh-pages.yml`:
 
 * Installs Node
+* Installs Python and Pillow
 * Builds Quartz
+* Compresses images via `build.py`
 * Uploads `public/` as a GitHub Pages artifact
 * Deploys with `actions/deploy-pages@v4`
 


### PR DESCRIPTION
## Summary
- run the python image compression script during CI
- mention the new step in the docs

## Testing
- `npm test` *(fails: `tsx` not found)*
- `npx quartz build` *(fails: unsupported node version)*

------
https://chatgpt.com/codex/tasks/task_e_684c53b6f208832b84743e80a9135fc5