### PR TITLE
Normalize tags in content

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Home"
-tags: [intro]
+tags: ["programming", "contents"]
 ---
 Welcome to **Infinite Mind Wiki** — a collection of interactive learning modules and experiments.
 

--- a/content/minecraft_movie_course/Day-1/00_introduction.md
+++ b/content/minecraft_movie_course/Day-1/00_introduction.md
@@ -1,6 +1,6 @@
 ---
 title: "0 - Introduction"
-tags: [minecraft, arts, film, tutorial]
+tags: ["programming", "contents"]
 ---
 # Introduction
 

--- a/content/minecraft_movie_course/Day-1/index.md
+++ b/content/minecraft_movie_course/Day-1/index.md
@@ -1,5 +1,5 @@
 ---
 title: Day 1
 
-tags: [minecraft, arts, film, contents]
+tags: ["programming", "contents"]
 ---

--- a/content/minecraft_movie_course/Day-10/00_celebrate_share.md
+++ b/content/minecraft_movie_course/Day-10/00_celebrate_share.md
@@ -1,6 +1,6 @@
 ---
 title: "1 - Celebrate and Share"
-tags: [minecraft, arts, film, tutorial]
+tags: ["programming", "contents"]
 ---
 # Celebrate and Share!
 

--- a/content/minecraft_movie_course/Day-10/index.md
+++ b/content/minecraft_movie_course/Day-10/index.md
@@ -1,5 +1,5 @@
 ---
 title: Day 10
 
-tags: [minecraft, arts, film, contents]
+tags: ["programming", "contents"]
 ---

--- a/content/minecraft_movie_course/Day-2/00_movie_genre.md
+++ b/content/minecraft_movie_course/Day-2/00_movie_genre.md
@@ -1,6 +1,6 @@
 ---
 title: "1 - Genres"
-tags: [minecraft, arts, film, tutorial]
+tags: ["programming", "contents"]
 ---
 # Genres
 

--- a/content/minecraft_movie_course/Day-2/index.md
+++ b/content/minecraft_movie_course/Day-2/index.md
@@ -1,5 +1,5 @@
 ---
 title: Day 2
 
-tags: [minecraft, arts, film, contents]
+tags: ["programming", "contents"]
 ---

--- a/content/minecraft_movie_course/Day-3/00_story_writing.md
+++ b/content/minecraft_movie_course/Day-3/00_story_writing.md
@@ -1,6 +1,6 @@
 ---
 title: "2 - Story Writing"
-tags: [minecraft, arts, film, tutorial]
+tags: ["programming", "contents"]
 ---
 # Story Writing
 

--- a/content/minecraft_movie_course/Day-3/index.md
+++ b/content/minecraft_movie_course/Day-3/index.md
@@ -1,5 +1,5 @@
 ---
 title: Day 3
 
-tags: [minecraft, arts, film, contents]
+tags: ["programming", "contents"]
 ---

--- a/content/minecraft_movie_course/Day-4/00_camera_angles.md
+++ b/content/minecraft_movie_course/Day-4/00_camera_angles.md
@@ -1,6 +1,6 @@
 ---
 title: "3 - Camera Angles"
-tags: [minecraft, arts, film, tutorial]
+tags: ["programming", "contents"]
 ---
 # Camera Angles
 

--- a/content/minecraft_movie_course/Day-4/index.md
+++ b/content/minecraft_movie_course/Day-4/index.md
@@ -1,5 +1,5 @@
 ---
 title: Day 4
 
-tags: [minecraft, arts, film, contents]
+tags: ["programming", "contents"]
 ---

--- a/content/minecraft_movie_course/Day-5/00_storyboards.md
+++ b/content/minecraft_movie_course/Day-5/00_storyboards.md
@@ -1,6 +1,6 @@
 ---
 title: "4 - Storyboard Design"
-tags: [minecraft, arts, film, tutorial]
+tags: ["programming", "contents"]
 ---
 # Storyboard Design
 

--- a/content/minecraft_movie_course/Day-5/index.md
+++ b/content/minecraft_movie_course/Day-5/index.md
@@ -1,5 +1,5 @@
 ---
 title: Day 5
 
-tags: [minecraft, arts, film, contents]
+tags: ["programming", "contents"]
 ---

--- a/content/minecraft_movie_course/Day-6/00_costume_design.md
+++ b/content/minecraft_movie_course/Day-6/00_costume_design.md
@@ -1,6 +1,6 @@
 ---
 title: "5 - Costume Design"
-tags: [minecraft, arts, film, tutorial]
+tags: ["programming", "contents"]
 ---
 # Costume Design
 

--- a/content/minecraft_movie_course/Day-6/index.md
+++ b/content/minecraft_movie_course/Day-6/index.md
@@ -1,5 +1,5 @@
 ---
 title: Day 6
 
-tags: [minecraft, arts, film, contents]
+tags: ["programming", "contents"]
 ---

--- a/content/minecraft_movie_course/Day-7/00_filming_part1.md
+++ b/content/minecraft_movie_course/Day-7/00_filming_part1.md
@@ -1,6 +1,6 @@
 ---
 title: "6 - Filming (PART 1)"
-tags: [minecraft, arts, film, tutorial]
+tags: ["programming", "contents"]
 ---
 # Filming (PART 1)
 

--- a/content/minecraft_movie_course/Day-7/index.md
+++ b/content/minecraft_movie_course/Day-7/index.md
@@ -1,5 +1,5 @@
 ---
 title: Day 7
 
-tags: [minecraft, arts, film, contents]
+tags: ["programming", "contents"]
 ---

--- a/content/minecraft_movie_course/Day-8/00_filming_part2.md
+++ b/content/minecraft_movie_course/Day-8/00_filming_part2.md
@@ -1,6 +1,6 @@
 ---
 title: "7 - Filming (PART 2)"
-tags: [minecraft, arts, film, tutorial]
+tags: ["programming", "contents"]
 ---
 # Filming (PART 2)
 

--- a/content/minecraft_movie_course/Day-8/index.md
+++ b/content/minecraft_movie_course/Day-8/index.md
@@ -1,5 +1,5 @@
 ---
 title: Day 8
 
-tags: [minecraft, arts, film, contents]
+tags: ["programming", "contents"]
 ---

--- a/content/minecraft_movie_course/Day-9/00_video_editing_voice_acting.md
+++ b/content/minecraft_movie_course/Day-9/00_video_editing_voice_acting.md
@@ -1,6 +1,6 @@
 ---
 title: "8 - Video Editing / Voice Acting"
-tags: [minecraft, arts, film, tutorial]
+tags: ["programming", "contents"]
 ---
 # Video Editing / Voice Acting
 

--- a/content/minecraft_movie_course/Day-9/index.md
+++ b/content/minecraft_movie_course/Day-9/index.md
@@ -1,5 +1,5 @@
 ---
 title: Day 9
 
-tags: [minecraft, arts, film, contents]
+tags: ["programming", "contents"]
 ---

--- a/content/minecraft_movie_course/index.md
+++ b/content/minecraft_movie_course/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Minecraft Movie Course"
-tags: [minecraft, arts, film, contents]
+tags: ["programming", "contents"]
 ---
 
 Welcome to **The Minecraft Movie Course – Make Your Own Film!** This beginner to intermediate class guides you from story planning to final editing. You'll use storyboards, Replay Mod, and CapCut to create a short movie complete with voice acting.

--- a/content/pilots_of_gallaxia/backstory.md
+++ b/content/pilots_of_gallaxia/backstory.md
@@ -1,6 +1,6 @@
 ---
 title: "Backstory"
-tags: [unplugged, story]
+tags: ["programming", "contents"]
 ---
 
 Far-off **Gallaxia** is filled with adventure and danger. Durriken invaders strive to rule, but glowing **Star Prisms** guard the worlds while daring Gallaxian pilots hold the line. The uneasy alliance between sectors is fraying—each suspects the others of plotting to free their "peace hostage" scientist first.

--- a/content/pilots_of_gallaxia/card_definitions.md
+++ b/content/pilots_of_gallaxia/card_definitions.md
@@ -1,6 +1,6 @@
 ---
 title: "Card Definitions"
-tags: [unplugged, tutorial]
+tags: ["programming", "contents"]
 enableToc: true
 ---
 

--- a/content/pilots_of_gallaxia/game_setup.md
+++ b/content/pilots_of_gallaxia/game_setup.md
@@ -1,6 +1,6 @@
 ---
 title: "Game Setup"
-tags: [unplugged, tutorial]
+tags: ["programming", "contents"]
 showToc: true
 ---
 

--- a/content/pilots_of_gallaxia/index.md
+++ b/content/pilots_of_gallaxia/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Pilots of Gallaxia"
-tags: ["unplugged", "all-ages", "contents"]
+tags: ["programming", "contents"]
 ---
 <img src="/images/low/galaxia/mainpage.webp" alt="Galaxia Main Image" style="border-radius: 12px; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);">
 

--- a/content/pilots_of_gallaxia/sample_turns.md
+++ b/content/pilots_of_gallaxia/sample_turns.md
@@ -1,6 +1,6 @@
 ---
 title: "Sample Turns"
-tags: [unplugged, tutorial]
+tags: ["programming", "contents"]
 ---
 
 ### Sample Turn A

--- a/content/robocode/Day-1/00_java_intro.md
+++ b/content/robocode/Day-1/00_java_intro.md
@@ -1,6 +1,6 @@
 ---
 title: "1 - Outline"
-tags: [robocode, programming, beginner, intro]
+tags: ["programming", "contents"]
 ---
 # Robocode Lab: Day 1 – Introduction
 

--- a/content/robocode/Day-1/01_setup_vscode.md
+++ b/content/robocode/Day-1/01_setup_vscode.md
@@ -1,6 +1,6 @@
 ---
 title: "2 - Setup with VS Code"
-tags: [robocode, programming, beginner]
+tags: ["programming", "contents"]
 ---
 # Set Up Java with Visual Studio Code
 

--- a/content/robocode/Day-1/02_setup_eclipse.md
+++ b/content/robocode/Day-1/02_setup_eclipse.md
@@ -1,6 +1,6 @@
 ---
 title: "3 - Setup with Eclipse"
-tags: [robocode, programming, beginner]
+tags: ["programming", "contents"]
 ---
 # Set Up Java with Eclipse
 

--- a/content/robocode/Day-1/03_hello_world.md
+++ b/content/robocode/Day-1/03_hello_world.md
@@ -1,6 +1,6 @@
 ---
 title: "4 - Hello World"
-tags: [robocode, programming, beginner]
+tags: ["programming", "contents"]
 ---
 # Your First Java Program
 

--- a/content/robocode/Day-1/index.md
+++ b/content/robocode/Day-1/index.md
@@ -1,4 +1,5 @@
 ---
 title: Day 1
 
-tags: [robocode, programming, contents]---
+tags: ["programming", "contents"]
+---

--- a/content/robocode/Day-2/00_variables_and_datatypes.md
+++ b/content/robocode/Day-2/00_variables_and_datatypes.md
@@ -1,6 +1,6 @@
 ---
 title: "1 - Variables and Datatypes"
-tags: [robocode, programming, beginner]
+tags: ["programming", "contents"]
 ---
 # Java Basics
 

--- a/content/robocode/Day-2/01_conditions.md
+++ b/content/robocode/Day-2/01_conditions.md
@@ -1,6 +1,6 @@
 ---
 title: "2 - Conditions"
-tags: [robocode, programming, beginner]
+tags: ["programming", "contents"]
 ---
 # Using Conditions
 

--- a/content/robocode/Day-2/index.md
+++ b/content/robocode/Day-2/index.md
@@ -1,6 +1,7 @@
 ---
 title: Day 2
 
-tags: [robocode, programming, contents]---
+tags: ["programming", "contents"]
+---
 - [Variables and Datatypes](./00_variables_and_datatypes)
 - [Conditions](./01_conditions)

--- a/content/robocode/Day-3/00_robocode_intro.md
+++ b/content/robocode/Day-3/00_robocode_intro.md
@@ -1,6 +1,6 @@
 ---
 title: "1 - Outline"
-tags: [robocode, programming, beginner, intro]
+tags: ["programming", "contents"]
 ---
 
 # Robocode Lab: Day 3 – Introduction

--- a/content/robocode/Day-3/01_setting_up.md
+++ b/content/robocode/Day-3/01_setting_up.md
@@ -1,6 +1,6 @@
 ---
 title: "2 - Setting Up"
-tags: [robocode, programming, beginner]
+tags: ["programming", "contents"]
 ---
 
 # Robocode Lab: Day 3 – Setting Up

--- a/content/robocode/Day-3/02_first_lines.md
+++ b/content/robocode/Day-3/02_first_lines.md
@@ -1,6 +1,6 @@
 ---
 title: "3 - First Lines of Code"
-tags: [robocode, programming, beginner]
+tags: ["programming", "contents"]
 ---
 # Robocode Lab: Day 3 – First Lines of Code
 

--- a/content/robocode/Day-3/index.md
+++ b/content/robocode/Day-3/index.md
@@ -1,4 +1,5 @@
 ---
 title: Day 3
 
-tags: [robocode, programming, contents]---
+tags: ["programming", "contents"]
+---

--- a/content/robocode/Day-4/00_movement_angles.md
+++ b/content/robocode/Day-4/00_movement_angles.md
@@ -1,6 +1,6 @@
 ---
 title: "1 - Movement and Angles"
-tags: [robocode, programming, beginner]
+tags: ["programming", "contents"]
 ---
 # Robocode Lab: Day 4 – Movement and Angles
 

--- a/content/robocode/Day-4/index.md
+++ b/content/robocode/Day-4/index.md
@@ -1,4 +1,5 @@
 ---
 title: Day 4
 
-tags: [robocode, programming, contents]---
+tags: ["programming", "contents"]
+---

--- a/content/robocode/index.md
+++ b/content/robocode/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Robocode Lab"
-tags: [robocode, programming, contents]
+tags: ["programming", "contents"]
 ---
 
 Welcome to the **RoboCode Lab** — a progressive series of programming challenges using Robocode.

--- a/content/robocode/tournament_format.md
+++ b/content/robocode/tournament_format.md
@@ -1,6 +1,6 @@
 ---
 title: "Tournament Format"
-tags: [robocode, programming, tutorial]
+tags: ["programming", "contents"]
 ---
 # Robocode 1 vs 1 Tournament
 

--- a/content/sustainability_lab/Day-1/00_getting_started.md
+++ b/content/sustainability_lab/Day-1/00_getting_started.md
@@ -1,6 +1,6 @@
 ---
 title: "1 - Getting Started"
-tags: [minecraft, sustainability, intro]
+tags: ["programming", "contents"]
 ---
 # Sustainability Lab: Day 1 – Getting Started
 

--- a/content/sustainability_lab/Day-1/01_choose_animal.md
+++ b/content/sustainability_lab/Day-1/01_choose_animal.md
@@ -1,7 +1,7 @@
 ---
 
 title: "2 - Choose Your Animal"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 -----------------------------------
 

--- a/content/sustainability_lab/Day-1/02_choose_disaster.md
+++ b/content/sustainability_lab/Day-1/02_choose_disaster.md
@@ -1,7 +1,7 @@
 ---
 
 title: "3 - Choose a Disaster"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 -------------------------------------------
 

--- a/content/sustainability_lab/Day-1/03_task_board.md
+++ b/content/sustainability_lab/Day-1/03_task_board.md
@@ -1,6 +1,6 @@
 ---
 title: "4 - Create a Task Board"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Create a Task Board
 

--- a/content/sustainability_lab/Day-1/04_survival_tasks.md
+++ b/content/sustainability_lab/Day-1/04_survival_tasks.md
@@ -1,6 +1,6 @@
 ---
 title: "5 - Survival Tasks"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Survival Tasks
 

--- a/content/sustainability_lab/Day-1/index.md
+++ b/content/sustainability_lab/Day-1/index.md
@@ -1,4 +1,5 @@
 ---
 title: Day 1
 
-tags: [minecraft, sustainability, contents]---
+tags: ["programming", "contents"]
+---

--- a/content/sustainability_lab/Day-1/sam_the_enderman.md
+++ b/content/sustainability_lab/Day-1/sam_the_enderman.md
@@ -1,6 +1,6 @@
 ---
 title: "Sam the enderman"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 **The Story of Sam the Enderman**
 

--- a/content/sustainability_lab/Day-2/00_intro.md
+++ b/content/sustainability_lab/Day-2/00_intro.md
@@ -1,6 +1,6 @@
 ---
 title: "1 - Day 2 Overview"
-tags: [minecraft, sustainability, intro]
+tags: ["programming", "contents"]
 ---
 
 # Sustainability Lab: Day 2 – Disaster Preparation

--- a/content/sustainability_lab/Day-2/01_tornado.md
+++ b/content/sustainability_lab/Day-2/01_tornado.md
@@ -1,6 +1,6 @@
 ---
 title: "Tornado Prep"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Prepare for Tornadoes
 

--- a/content/sustainability_lab/Day-2/02_tsunami.md
+++ b/content/sustainability_lab/Day-2/02_tsunami.md
@@ -1,6 +1,6 @@
 ---
 title: "Tsunami Prep"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Prepare for Tsunamis
 

--- a/content/sustainability_lab/Day-2/03_earthquake.md
+++ b/content/sustainability_lab/Day-2/03_earthquake.md
@@ -1,6 +1,6 @@
 ---
 title: "Earthquake Prep"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Prepare for Earthquakes
 

--- a/content/sustainability_lab/Day-2/04_flood.md
+++ b/content/sustainability_lab/Day-2/04_flood.md
@@ -1,6 +1,6 @@
 ---
 title: "Flood Prep"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Prepare for Floods
 

--- a/content/sustainability_lab/Day-2/05_alarm_system.md
+++ b/content/sustainability_lab/Day-2/05_alarm_system.md
@@ -1,6 +1,6 @@
 ---
 title: "2 - Alarm Systems"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Build an Alarm System
 

--- a/content/sustainability_lab/Day-2/index.md
+++ b/content/sustainability_lab/Day-2/index.md
@@ -1,4 +1,4 @@
 ---
 title: Day 2
-tags: [minecraft, sustainability, contents]
+tags: ["programming", "contents"]
 ---

--- a/content/sustainability_lab/Day-3/00_intro.md
+++ b/content/sustainability_lab/Day-3/00_intro.md
@@ -1,6 +1,6 @@
 ---
 title: "1 - Sustainable Energy"
-tags: [minecraft, sustainability, intro]
+tags: ["programming", "contents"]
 ---
 
 # Sustainability Lab: Day 3 – Sustainable Energy

--- a/content/sustainability_lab/Day-3/01_backstory.md
+++ b/content/sustainability_lab/Day-3/01_backstory.md
@@ -1,6 +1,6 @@
 ---
 title: "2 - Village Backstory"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Write Your Village Backstory
 

--- a/content/sustainability_lab/Day-3/02_solar.md
+++ b/content/sustainability_lab/Day-3/02_solar.md
@@ -1,6 +1,6 @@
 ---
 title: "Solar Power"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 
 # Solar Power ☀️

--- a/content/sustainability_lab/Day-3/03_wind.md
+++ b/content/sustainability_lab/Day-3/03_wind.md
@@ -1,6 +1,6 @@
 ---
 title: "Wind Power"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 
 # Wind Power 🌬️

--- a/content/sustainability_lab/Day-3/04_hydro.md
+++ b/content/sustainability_lab/Day-3/04_hydro.md
@@ -1,6 +1,6 @@
 ---
 title: "Hydropower"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 
 # Hydropower 🌊

--- a/content/sustainability_lab/Day-3/05_geothermal.md
+++ b/content/sustainability_lab/Day-3/05_geothermal.md
@@ -1,6 +1,6 @@
 ---
 title: "Geothermal"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 
 # Geothermal 🌋

--- a/content/sustainability_lab/Day-3/06_nuclear.md
+++ b/content/sustainability_lab/Day-3/06_nuclear.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Nuclear Fusion"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 -----------------------------------------------------
 

--- a/content/sustainability_lab/Day-3/07_tidal.md
+++ b/content/sustainability_lab/Day-3/07_tidal.md
@@ -1,6 +1,6 @@
 ---
 title: "Tidal Power"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 
 # Tidal Power 🐋

--- a/content/sustainability_lab/Day-3/index.md
+++ b/content/sustainability_lab/Day-3/index.md
@@ -1,4 +1,4 @@
 ---
 title: Day 3
-tags: [minecraft, sustainability, contents]
+tags: ["programming", "contents"]
 ---

--- a/content/sustainability_lab/Day-4/00_market.md
+++ b/content/sustainability_lab/Day-4/00_market.md
@@ -1,6 +1,6 @@
 ---
 title: "1 - Market Day"
-tags: [minecraft, sustainability, intro]
+tags: ["programming", "contents"]
 ---
 # Build a Market
 

--- a/content/sustainability_lab/Day-4/01_protagonist.md
+++ b/content/sustainability_lab/Day-4/01_protagonist.md
@@ -1,6 +1,6 @@
 ---
 title: "2 - The Protagonist"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Develop a Protagonist
 

--- a/content/sustainability_lab/Day-4/index.md
+++ b/content/sustainability_lab/Day-4/index.md
@@ -1,4 +1,4 @@
 ---
 title: Day 4
-tags: [minecraft, sustainability, contents]
+tags: ["programming", "contents"]
 ---

--- a/content/sustainability_lab/Day-5/00_government.md
+++ b/content/sustainability_lab/Day-5/00_government.md
@@ -1,6 +1,6 @@
 ---
 title: "1 - Community Government"
-tags: [minecraft, sustainability, intro]
+tags: ["programming", "contents"]
 ---
 # Plan a Government
 

--- a/content/sustainability_lab/Day-5/01_voting.md
+++ b/content/sustainability_lab/Day-5/01_voting.md
@@ -1,6 +1,6 @@
 ---
 title: "2 - Voting Mini-Game"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Voting Mini-Game
 

--- a/content/sustainability_lab/Day-5/02_write_laws.md
+++ b/content/sustainability_lab/Day-5/02_write_laws.md
@@ -1,6 +1,6 @@
 ---
 title: "3 - Write the Laws"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Write the Laws
 

--- a/content/sustainability_lab/Day-5/03_movie_knight.md
+++ b/content/sustainability_lab/Day-5/03_movie_knight.md
@@ -1,6 +1,6 @@
 ---
 title: "4 - Movie Knight"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Movie Knight
 

--- a/content/sustainability_lab/Day-5/index.md
+++ b/content/sustainability_lab/Day-5/index.md
@@ -1,7 +1,8 @@
 ---
 title: "Day 5 – Highlight"
 
-tags: [minecraft, sustainability, contents]---
+tags: ["programming", "contents"]
+---
 
 ## "H" is for Highlight!
 

--- a/content/sustainability_lab/Day-6/00_ongoing_challenges.md
+++ b/content/sustainability_lab/Day-6/00_ongoing_challenges.md
@@ -1,6 +1,6 @@
 ---
 title: "1 - Ongoing Challenges"
-tags: [minecraft, sustainability, intro]
+tags: ["programming", "contents"]
 ---
 # Day 6+ – Ongoing Challenges
 

--- a/content/sustainability_lab/Day-6/01_languages.md
+++ b/content/sustainability_lab/Day-6/01_languages.md
@@ -1,7 +1,7 @@
 ---
 
 title: "2 - Invent Languages"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 -------------------------------------------
 

--- a/content/sustainability_lab/Day-6/02_youth_justice.md
+++ b/content/sustainability_lab/Day-6/02_youth_justice.md
@@ -1,6 +1,6 @@
 ---
 title: "3 - Youth Justice"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Youth Justice
 

--- a/content/sustainability_lab/Day-6/03_real_world.md
+++ b/content/sustainability_lab/Day-6/03_real_world.md
@@ -1,6 +1,6 @@
 ---
 title: "4 - Real-World Inspiration"
-tags: [minecraft, sustainability]
+tags: ["programming", "contents"]
 ---
 # Real-World Inspiration
 

--- a/content/sustainability_lab/Day-6/index.md
+++ b/content/sustainability_lab/Day-6/index.md
@@ -1,4 +1,5 @@
 ---
 title: Day 6+
 
-tags: [minecraft, sustainability, contents]---
+tags: ["programming", "contents"]
+---

--- a/content/sustainability_lab/index.md
+++ b/content/sustainability_lab/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Sustainability Lab"
-tags: [minecraft, sustainability, contents]
+tags: ["programming", "contents"]
 ---
 
 Welcome to the **Sustainability Lab**, a hands-on series of Minecraft challenges focused on sustainable energy and collaborative play. The course begins with an orientation tour of an existing sustainable village. You'll pick a sustainable energy source, teleport to a biome, and choose a special animal to join your adventure.


### PR DESCRIPTION
## Summary
- update tags on all Markdown files in `content/` to use `["programming", "contents"]`
- fix several index pages with malformed frontmatter

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c90fbf6e4832b907194efa18b8cb9