### PR TITLE
Add EarthCraft Camp structure

### DIFF
--- a/content/earthcraft_olympiad/Day-1/index.md
+++ b/content/earthcraft_olympiad/Day-1/index.md
@@ -1,0 +1,12 @@
+---
+title: Day 1
+
+tags: ["minecraft", "sustainability", "contents", "hands-on"]
+---
+
+### Orientation & Teams
+
+- Synchronous play on the Minecraft server
+- Introduce the Earth/Venus ecolympics concept
+- Explore the 1:1500 Earth map
+- Choose from 6 energy teams and design e-flags

--- a/content/earthcraft_olympiad/Day-2/index.md
+++ b/content/earthcraft_olympiad/Day-2/index.md
@@ -1,0 +1,13 @@
+---
+title: Day 2
+
+tags: ["minecraft", "sustainability", "contents", "hands-on"]
+---
+
+### Natural Anthems
+
+- Meet the 16 SDG animal mascots
+- Compose natural anthems for energy
+- Discuss "national best" and "national worst" examples
+- Experiment with the dymaxion earth d20
+- Learn about dual citizenship for the games

--- a/content/earthcraft_olympiad/Day-3/index.md
+++ b/content/earthcraft_olympiad/Day-3/index.md
@@ -1,0 +1,13 @@
+---
+title: Day 3
+
+tags: ["minecraft", "sustainability", "contents", "hands-on"]
+---
+
+### Challenges & Bosses
+
+- Strive for a Net Zero world
+- Befriend the three-headed Wither
+- Encounter four Enderdragons causing chaos
+- Understand Team Venus vs Team Earth dynamics
+- Gather backstory fragments across dimensions

--- a/content/earthcraft_olympiad/Day-4/index.md
+++ b/content/earthcraft_olympiad/Day-4/index.md
@@ -1,0 +1,13 @@
+---
+title: Day 4
+
+tags: ["minecraft", "sustainability", "contents", "hands-on"]
+---
+
+### Speak Friend & Enter
+
+- Learn phrases for "friend" in new languages
+- Practice the f.r.i.e.n.d. ideals
+- Empower animals, plants, and stones with voice
+- Begin the Shipwreck Earth Survival Server
+- Navigate the Sustainability Maze together

--- a/content/earthcraft_olympiad/Day-5/index.md
+++ b/content/earthcraft_olympiad/Day-5/index.md
@@ -1,0 +1,13 @@
+---
+title: Day 5
+
+tags: ["minecraft", "sustainability", "contents", "hands-on"]
+---
+
+### Finale & Tools
+
+- Rotate through governance styles for each shipwreck
+- Celebrate Team Refugee and partnership for the goals
+- Use MakeCode World Edit v1.3 and structure blocks
+- Copy and paste builds with a wooden axe
+- Prepare the world for future ECOlympics

--- a/content/earthcraft_olympiad/index.md
+++ b/content/earthcraft_olympiad/index.md
@@ -1,0 +1,14 @@
+---
+title: "EarthCraft Olympiad"
+tags: ["minecraft", "sustainability", "synchronous", "contents"]
+---
+
+**EarthCraft Olympiad** is a five‑day Minecraft camp that blends ecology, energy, and economy. Each day introduces new challenges and collaborative play.
+
+## Camp Schedule
+
+- [Day 1 – Orientation & Teams](./Day-1/)
+- [Day 2 – Natural Anthems](./Day-2/)
+- [Day 3 – Challenges & Bosses](./Day-3/)
+- [Day 4 – Speak Friend & Enter](./Day-4/)
+- [Day 5 – Finale & Tools](./Day-5/)

--- a/content/index.md
+++ b/content/index.md
@@ -21,3 +21,7 @@ Learn the basics of filmmaking by creating your own Minecraft movie from script 
 ### 🚀 [RoboCode Lab](./robocode/)
 
 Explore the fundamentals of programming and combat AI using Robocode.
+
+### 🏅 [EarthCraft Olympiad](./earthcraft_olympiad/)
+
+A five-day camp of collaborative Minecraft competitions focused on ecology, energy, and economy.


### PR DESCRIPTION
## Summary
- restructure EarthCraft section into a five‑day camp
- link to each day from the Olympiad index page
- describe the camp from the home page

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db843f9b8832bbcd8ef21221eed49