### PR TITLE
Move Robocode setup instructions to Day 1

### DIFF
--- a/content/robocode/Day-1/02_hello_world.md
+++ b/content/robocode/Day-1/02_hello_world.md
@@ -43,4 +43,4 @@ Hello, world!
 ## 🗺️ Navigation
 
 ⬅️ [Back: Setup with VS Code](/robocode/Day-1/01_setup_vscode)
-➡️ [Next: Day 2 - Robocode Intro](/robocode/Day-2/00_robocode_intro)
+➡️ [Next: Setting Up Robocode](/robocode/Day-1/03_setting_up)

--- a/content/robocode/Day-1/03_setting_up.md
+++ b/content/robocode/Day-1/03_setting_up.md
@@ -1,11 +1,11 @@
 ---
-title: "2 - Setting Up"
-tags: ["robocode", "tutorial", "hands-on", "cs", "intermediate"]
+title: "3 - Setting Up Robocode"
+tags: ["robocode", "tutorial", "hands-on", "cs", "beginner"]
 ---
 
-> Let's tackle **2 - Setting Up** 😀
+> Let's tackle **3 - Setting Up Robocode** 😀
 
-# Robocode Lab: Day 3 – Setting Up
+# Robocode Lab: Day 1 – Setting Up Robocode
 
 Before we start programming robots, let's make sure your environment is ready.
 
@@ -38,5 +38,5 @@ Download the ZIP file provided by your instructor. It contains everything you ne
 
 ## Navigation
 
-⬅️ [Back: Introduction](/robocode/Day-2/00_robocode_intro)
-➡️ [Next: First Lines of Code](/robocode/Day-2/02_first_lines)
+⬅️ [Back: Hello World Program](/robocode/Day-1/02_hello_world)
+➡️ [Next: Day 2 - Robocode Intro](/robocode/Day-2/00_robocode_intro)

--- a/content/robocode/Day-1/index.md
+++ b/content/robocode/Day-1/index.md
@@ -5,3 +5,7 @@ tags: ["robocode", "contents", "cs", "beginner"]
 ---
 
 > Gear up for **Day 1** 😀
+- [Outline](/robocode/Day-1/00_java_intro)
+- [Setup with VS Code](/robocode/Day-1/01_setup_vscode)
+- [Hello World Program](/robocode/Day-1/02_hello_world)
+- [Setting Up Robocode](/robocode/Day-1/03_setting_up)

--- a/content/robocode/Day-2/00_robocode_intro.md
+++ b/content/robocode/Day-2/00_robocode_intro.md
@@ -22,4 +22,4 @@ Welcome to the **Robocode Lab**! In this module, you'll get a high-level overvie
 
 ## Next Steps
 
-➡️ [Next: Setting Up](/robocode/Day-2/01_setting_up)
+➡️ [Next: First Lines of Code](/robocode/Day-2/02_first_lines)

--- a/content/robocode/Day-2/02_first_lines.md
+++ b/content/robocode/Day-2/02_first_lines.md
@@ -161,5 +161,5 @@ We’ll dive deeper into event handling and how to fine-tune your robot’s reac
 
 ## 🔗 Navigation
 
-⬅️ [Back: Setting Up](/robocode/Day-2/01_setting_up)
+⬅️ [Back: Setting Up Robocode](/robocode/Day-1/03_setting_up)
 ➡️ [Next: Using VS Code](/robocode/Day-2/03_vscode_workspace)

--- a/content/robocode/Day-2/index.md
+++ b/content/robocode/Day-2/index.md
@@ -6,6 +6,5 @@ tags: ["robocode", "contents", "cs", "intermediate"]
 
 > Buckle up for **Day 2** 😀
 - [Outline](/robocode/Day-2/00_robocode_intro)
-- [Setting Up](/robocode/Day-2/01_setting_up)
 - [First Lines of Code](/robocode/Day-2/02_first_lines)
 - [Using VS Code](/robocode/Day-2/03_vscode_workspace)


### PR DESCRIPTION
## Summary
- move "Setting Up" lesson from Day 2 into Day 1 as `03_setting_up.md`
- update navigation links for Day 1 and Day 2
- adjust day indexes to reflect the new ordering

## Testing
- `npm run check` *(fails: Cannot find module 'source-map-support')*

------
https://chatgpt.com/codex/tasks/task_e_6855f7273b90832baf7461bb46e7e367