### PR TITLE
Add VS Code run configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Quartz and Build",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npx",
+      "args": [
+        "quartz",
+        "build",
+        "--serve"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "postDebugTask": "python-build"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "python-build",
+      "type": "shell",
+      "command": "python build.py",
+      "group": "none",
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add launch configuration to run Quartz and Python build script sequentially
- include corresponding task for the python build step

## Testing
- `npm test` *(fails: tsx not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ee3e23e8832bbe12885b6e5aba61