### PR TITLE
Fix bread link and extras index

### DIFF
--- a/content/robocode/Day-1/02_hello_world.md
+++ b/content/robocode/Day-1/02_hello_world.md
@@ -38,7 +38,7 @@ Hello World!
 🎉 Woohoo! That means Java is working, and you're ready to start building robots!
 
 [What does javac and java do?](/robocode/Day-1/javacompile)
-[That was confusing, what does javac and java really do?](/robocode/bread)
+[That was confusing, what does javac and java really do?](/robocode/extras/bread)
 
 ---
 

--- a/content/robocode/extras/index.md
+++ b/content/robocode/extras/index.md
@@ -3,4 +3,9 @@ title: "Extra Information"
 tags: ["robocode", "contents", "cs"]
 ---
 
+## Extra Guides
 
+- [Bread‑Making Analogy](/robocode/extras/bread)
+- [Exponential Averaging](/robocode/extras/exp_avg)
+- [Robocode Library](/robocode/extras/robocode_library)
+- [Vocabulary](/robocode/extras/vocab)

--- a/content/robocode/index.md
+++ b/content/robocode/index.md
@@ -44,6 +44,7 @@ Finale: A **Robocode tournament** with a focus on **kindness**, **peer feedback*
 
 [Course Requirements](/robocode/requirements)
 [Course Outcomes](/robocode/outcomes)
+[Extras](/robocode/extras/)
 
 ---
 


### PR DESCRIPTION
## Summary
- fix broken bread link in Hello World page
- add quick index for extras materials
- link robocode index page to the extras index

## Testing
- `npm run check` *(fails: Cannot find module 'util' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685d84a60f84832badada731e034253d