### PR TITLE
Fix Day 1 page links and numbering

### DIFF
--- a/content/robocode/Day-1/02_setting_up.md
+++ b/content/robocode/Day-1/02_setting_up.md
@@ -1,9 +1,9 @@
 ---
-title: "5 - Setting Up Robocode"
+title: "4 - Setting Up Robocode"
 tags: ["robocode", "tutorial", "hands-on", "cs", "beginner"]
 ---
 
-> Let's tackle **3 - Setting Up Robocode** 😀
+> Let's tackle **4 - Setting Up Robocode** 😀
 
 # Robocode Lab: Day 1 – Setting Up Robocode
 

--- a/content/robocode/Day-1/03_hello_world.md
+++ b/content/robocode/Day-1/03_hello_world.md
@@ -1,8 +1,8 @@
 ---
-title: "4 - Hello World"
+title: "5 - Hello World"
 tags: ["robocode", "tutorial", "hands-on", "cs", "beginner"]
 ---
-> Let’s jump into **4 - Hello World** 🎉
+> Let’s jump into **5 - Hello World** 🎉
 
 # 🧪 Your First Java Program
 

--- a/content/robocode/Day-1/04_minigame.md
+++ b/content/robocode/Day-1/04_minigame.md
@@ -5,3 +5,8 @@ tags: ["robocode"]
 
 <iframe src="https://axyl-casc.github.io/WikiMinigames/dodge.html"
   style="width: 100%; height: 100%; min-height: 600px; border: none; border-radius: 8px;"></iframe>
+
+## Navigation
+
+⬅️ [Back: Hello World Program](/robocode/Day-1/03_hello_world)
+➡️ [Next: Day 2 - Robocode Intro](/robocode/Day-2/00_robocode_intro)

--- a/content/robocode/Day-1/index.md
+++ b/content/robocode/Day-1/index.md
@@ -20,5 +20,5 @@ tags: ["robocode", "contents", "cs", "beginner"]
 - [Introductions](/robocode/Day-1/introductions)
 - [Outline](/robocode/Day-1/00_java_intro)
 - [Setup with VS Code](/robocode/Day-1/01_setup_vscode)
-- [Setting Up Robocode](/robocode/Day-1/03_setting_up)
-- [Hello World Program](/robocode/Day-1/02_hello_world)
+- [Setting Up Robocode](/robocode/Day-1/02_setting_up)
+- [Hello World Program](/robocode/Day-1/03_hello_world)

--- a/content/robocode/Day-2/02_first_lines.md
+++ b/content/robocode/Day-2/02_first_lines.md
@@ -117,5 +117,5 @@ You're now officially a Java coder! 🚀 Keep experimenting with values and even
 
 ## 🔗 Navigation
 
-🔹 [Back: Robocode Setup](/robocode/Day-1/03_setting_up)
+🔹 [Back: Robocode Setup](/robocode/Day-1/02_setting_up)
 🔹 [Next: Understanding Robocode Geometry](/robocode/Day-2/03_geometry)


### PR DESCRIPTION
## Summary
- fix internal links on Day 1 index
- correct numbering in Day 1 setup and hello world pages
- add navigation links to Day 1 minigame
- update Day 2 back link to Day 1 setup

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b1b83af8832b80cac985d0509920