### PR TITLE
Add player card page for day 10

### DIFF
--- a/content/robocode/Day-10/02_wrap_up.md
+++ b/content/robocode/Day-10/02_wrap_up.md
@@ -8,4 +8,4 @@ tags: ["robocode", "tutorial", "hands-on", "cs", "intermediate"]
 Take a moment to share final thoughts and thank your teammates. Save your best code and keep exploring new robot ideas!
 
 ⬅️ [Back: Peer Assessment](/robocode/Day-10/01_peer_reflection)
-➡️ [Next: Day 10+](/robocode/Day-10+/index)
+➡️ [Next: Create Your Player Card](/robocode/Day-10/03_player_card)

--- a/content/robocode/Day-10/03_player_card.md
+++ b/content/robocode/Day-10/03_player_card.md
@@ -1,0 +1,24 @@
+---
+title: "4 - Create Your Player Card"
+tags: ["robocode", "tutorial", "hands-on", "cs", "intermediate"]
+---
+
+> Showcase your robot by designing a personalized player card.
+
+<iframe src="https://axyl-casc.github.io/WikiMinigames/cardgen/"
+  style="width: 100%; height: 100%; min-height: 600px; border: none; border-radius: 8px;"></iframe>
+
+## Capture a Screenshot
+
+Use the Windows **Snipping Tool** to grab a clean shot of your bot during a battle:
+
+1. Open Robocode and start a match so your robot is on screen.
+2. Press `Win + Shift + S` to launch the Snipping Tool.
+3. Drag to select the battle area you want to capture.
+4. Release the mouse to copy the screenshot to your clipboard.
+5. Paste (`Ctrl + V`) into Paint or your favorite editor and save the image.
+
+A crisp screenshot looks great on your player card!
+
+⬅️ [Back: Wrapping Up](/robocode/Day-10/02_wrap_up)
+➡️ [Next: Day 10+](/robocode/Day-10+/index)

--- a/content/robocode/Day-10/index.md
+++ b/content/robocode/Day-10/index.md
@@ -22,6 +22,7 @@ tags: ["robocode", "contents", "cs", "intermediate"]
 - [Tournament Day](/robocode/Day-10/00_tournament_overview)
 - [Peer Assessment & Reflection](/robocode/Day-10/01_peer_reflection)
 - [Wrapping Up](/robocode/Day-10/02_wrap_up)
+- [Create Your Player Card](/robocode/Day-10/03_player_card)
 
 ⬅️ [Back: Day 9](/robocode/Day-9/index)
 ➡️ [Next: Day 10+](/robocode/Day-10+/index)


### PR DESCRIPTION
## Summary
- create `03_player_card.md` with iframe to the card generator
- update navigation on Day 10 index and wrap-up page

## Testing
- `npm run check` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68659d5d0b4c832b9919398bb47fbd3c