### PR TITLE
Add Robocode Day 5 review tournament

### DIFF
--- a/content/robocode/Day-4/02_hit_by_bullet_event.md
+++ b/content/robocode/Day-4/02_hit_by_bullet_event.md
@@ -55,4 +55,4 @@ But for now, this two‑line dodge keeps things simple and fun.
 ## Navigation
 
 ⬅️ [Back: ScannedRobotEvent](/robocode/Day-4/01_scanned_robot_event)
-➡️ [Next: Boolean Basics](/robocode/Day-6/00_boolean_basics)
+➡️ [Next: Day 5](/robocode/Day-5/index)

--- a/content/robocode/Day-5/00_tournament_overview.md
+++ b/content/robocode/Day-5/00_tournament_overview.md
@@ -1,0 +1,21 @@
+---
+title: "1 - Tournament Day"
+tags:
+  - robocode
+  - tutorial
+  - hands-on
+  - cs
+  - intermediate
+---
+
+> Kick off Day 5 with a friendly tournament.
+
+## Overview
+
+- Celebrate through a friendly competition.
+- Showcase unique robot designs and strategies.
+
+We'll run a [round-robin tournament](/robocode/tournament_format) where every student battles each other once. Mark the top three finishers on each player's tank card with **1**, **2**, or **3**.
+
+⬅️ [Back: Day 4](/robocode/Day-4/index)
+➡️ [Next: Peer Assessment](/robocode/Day-5/01_peer_reflection)

--- a/content/robocode/Day-5/01_peer_reflection.md
+++ b/content/robocode/Day-5/01_peer_reflection.md
@@ -1,0 +1,20 @@
+---
+title: "2 - Peer Assessment & Reflection"
+tags:
+  - robocode
+  - tutorial
+  - hands-on
+  - cs
+  - intermediate
+---
+
+> After the battles, pause to reflect on your work.
+
+Use peer feedback or informal discussions to highlight:
+
+- What strategy worked well?
+- Which coding decisions need improvement?
+- How would you redesign your robot for the next event?
+
+⬅️ [Back: Tournament Day](/robocode/Day-5/00_tournament_overview)
+➡️ [Next: Wrap Up](/robocode/Day-5/02_wrap_up)

--- a/content/robocode/Day-5/02_wrap_up.md
+++ b/content/robocode/Day-5/02_wrap_up.md
@@ -1,0 +1,16 @@
+---
+title: "3 - Wrapping Up"
+tags:
+  - robocode
+  - tutorial
+  - hands-on
+  - cs
+  - intermediate
+---
+
+> Celebrate completing the first week of Robocode.
+
+Share final thoughts and thank your teammates. Save your best code and keep exploring new robot ideas!
+
+⬅️ [Back: Peer Assessment](/robocode/Day-5/01_peer_reflection)
+➡️ [Next: Create Your Player Card](/robocode/Day-5/03_player_card)

--- a/content/robocode/Day-5/03_player_card.md
+++ b/content/robocode/Day-5/03_player_card.md
@@ -1,0 +1,30 @@
+---
+title: "4 - Create Your Player Card"
+tags:
+  - robocode
+  - tutorial
+  - hands-on
+  - cs
+  - intermediate
+---
+
+> Showcase your robot by designing a personalized player card.
+
+<iframe src="https://axyl-casc.github.io/WikiMinigames/cardgen/"
+  style="width: 100%; height: 100%; min-height: 820px; border: none; border-radius: 8px;"></iframe>
+
+## Capture a Screenshot
+
+Use the Windows **Snipping Tool** to grab a clean shot of your bot during a battle:
+
+1. Open Robocode and start a match so your robot is on screen.
+2. Press `Win + Shift + S` to launch the Snipping Tool.
+3. Drag to select the battle area you want to capture.
+4. Release the mouse to copy the screenshot to your clipboard.
+5. Paste (`Ctrl + V`) into Paint or your favorite editor and save the image.
+
+A crisp screenshot looks great on your player card!
+
+⬅️ [Back: Wrapping Up](/robocode/Day-5/02_wrap_up)
+➡️ [Next: Day 6](/robocode/Day-6/index)
+

--- a/content/robocode/Day-5/index.md
+++ b/content/robocode/Day-5/index.md
@@ -8,4 +8,25 @@ tags:
   - intermediate
 ---
 
-Day 5 has been merged into [Day 6](../Day-6/). Continue there to keep learning.
+## Lesson Requirements
+
+* Bring your latest robot code ready to battle
+* Have Robocode installed and working
+* Prepare notes for reflection
+
+## Lesson Outcomes
+
+* Compete in a friendly tournament
+* Create a player card for your robot
+* Reflect on strengths and weaknesses
+
+> Day 5 is a mid-course review featuring a **friendly tournament** and time to design your player card.
+
+## Pages
+- [Tournament Day](/robocode/Day-5/00_tournament_overview)
+- [Peer Assessment & Reflection](/robocode/Day-5/01_peer_reflection)
+- [Wrapping Up](/robocode/Day-5/02_wrap_up)
+- [Create Your Player Card](/robocode/Day-5/03_player_card)
+
+⬅️ [Back: Day 4](/robocode/Day-4/index)
+➡️ [Next: Day 6](/robocode/Day-6/index)

--- a/content/robocode/Day-7/review.md
+++ b/content/robocode/Day-7/review.md
@@ -17,7 +17,7 @@ We started with the basics and steadily built up our robot:
 - **Day 2** – Wrote a custom robot and learned the VS Code workflow.
 - **Day 3** – Introduced variables and datatypes for robot state.
 - **Day 4** – Responded to events and printed debug messages.
-- **Day 5** – Practiced conditionals and loops to drive behavior.
+- **Day 5** – Held a friendly tournament and created player cards.
 
 Take a moment to review your code from each day. Notice how your robot has grown more organized and reactive.
 

--- a/content/robocode/index.md
+++ b/content/robocode/index.md
@@ -77,9 +77,9 @@ Finale: A **Robocode tournament** with a focus on **kindness**, **peer feedback*
 - Use print statements as narrative tools
 - Celebrate every bug as a clue
 
-### Day 5
+### [🏁 Day 5: Review Tournament](/robocode/Day-5/)
 
-Content moved to [Day 6](/robocode/Day-6/).
+- Friendly tournament and player cards
 
 ### [🔁 Day 6: Logic & Loops](/robocode/Day-6/)
 


### PR DESCRIPTION
## Summary
- revive Day 5 with a tournament review similar to Day 10
- add pages for tournament day, reflection, wrap up and player cards
- update navigation from Day 4 and weekly review
- list Day 5 in main robocode index

## Testing
- `npm run check` *(fails: cannot reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_6869a8c33c6c832bbbee33b9dcc10c18