### PR TITLE
Fix robocode navigation links and numbering

### DIFF
--- a/content/robocode/Day-1/index.md
+++ b/content/robocode/Day-1/index.md
@@ -28,4 +28,4 @@ tags:
 - [Setup with VS Code](/robocode/Day-1/01_setup_vscode)
 - [Setting Up Robocode](/robocode/Day-1/02_setting_up)
 - [Hello World Program](/robocode/Day-1/03_hello_world)
-- [Player Profiles](/robocode/Day-1/05_player_profiles)
+- [Player Profiles](/robocode/Day-1/04_player_profiles)

--- a/content/robocode/Day-7/01_basic_debugging.md
+++ b/content/robocode/Day-7/01_basic_debugging.md
@@ -111,4 +111,4 @@ Keep asking: "What did I _expect_ to happen? What actually happened?"
 ## Navigation
 
 ⬅️ [Back: try/catch Basics](/robocode/Day-7/00_try_catch)
-➡️ [Next: Day 8](/robocode/Day-7/02_methods_and_classes)
+➡️ [Next: Methods and Classes](/robocode/Day-7/02_methods_and_classes)

--- a/content/robocode/Day-7/02_methods_and_classes.md
+++ b/content/robocode/Day-7/02_methods_and_classes.md
@@ -1,5 +1,5 @@
 ---
-title: "1 - Methods and Classes"
+title: "3 - Methods and Classes"
 tags:
   - robocode
   - tutorial
@@ -8,7 +8,7 @@ tags:
   - intermediate
 ---
 
-> Diving into **1 - Methods and Classes** 🤖
+> Diving into **3 - Methods and Classes** 🤖
 
 # Why Use Methods?
 
@@ -40,5 +40,5 @@ The modular code will be easier to add new behaviour to and will increase your b
 
 ## Navigation
 
-⬅️ [Back: Reactionary Logic](/robocode/Day-7/01_basic_debugging)
+⬅️ [Back: Debugging with Patience](/robocode/Day-7/01_basic_debugging)
 ➡️ [Next: Helper Methods](/robocode/Day-7/03_helper_methods)

--- a/content/robocode/Day-7/03_helper_methods.md
+++ b/content/robocode/Day-7/03_helper_methods.md
@@ -1,5 +1,5 @@
 ---
-title: "2 - Helper Methods"
+title: "4 - Helper Methods"
 tags:
   - robocode
   - tutorial
@@ -8,7 +8,7 @@ tags:
   - intermediate
 ---
 
-> Check out **2 - Helper Methods** 😎
+> Check out **4 - Helper Methods** 😎
 
 # Breaking Up `run()`
 

--- a/content/robocode/Day-7/04_ownership_naming.md
+++ b/content/robocode/Day-7/04_ownership_naming.md
@@ -1,5 +1,5 @@
 ---
-title: "3 - Ownership & Naming"
+title: "5 - Ownership & Naming"
 tags:
   - robocode
   - tutorial
@@ -8,7 +8,7 @@ tags:
   - intermediate
 ---
 
-> Let's explore **3 - Ownership & Naming** 🤖
+> Let's explore **5 - Ownership & Naming** 🤖
 
 # 🧠 Code Ownership
 

--- a/content/robocode/Day-8/00_hit_reaction_plan.md
+++ b/content/robocode/Day-8/00_hit_reaction_plan.md
@@ -130,4 +130,4 @@ Once you're done, turn it into methods and `if` statements in your code.
 ## Navigation
 
 ⬅️ [Back: Basic Debugging](/robocode/Day-7/01_basic_debugging)
-➡️ [Next: Day 8](/robocode/Day-8/survival_strategies)
+➡️ [Next: Survival Strategies](/robocode/Day-8/01_survival_strategies)


### PR DESCRIPTION
## Summary
- fix broken player profiles link for day 1
- correct next links for day 7 and day 8 pages
- fix wrong 'Reactionary Logic' label
- update lesson numbering for day 7 modules

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c1a287ac8832b817fbc4913e8d20e