### PR TITLE
Add player profiles for Robocode

### DIFF
--- a/content/robocode/player_profiles/achiever.md
+++ b/content/robocode/player_profiles/achiever.md
@@ -1,0 +1,25 @@
+---
+title: "Achiever 🏆"
+tags:
+  - robocode
+  - player-profile
+---
+
+# Achiever 🏆
+
+**Motivation:** Mastery, Growth, Accomplishment
+
+**Catchphrase:** "Give me goals and let me prove myself."
+
+Achievers flourish when presented with structured challenges and opportunities for advancement. They enjoy leveling up, mastering skills, and receiving recognition. Socially, they connect with other high performers and often thrive on collaboration with like-minded peers.
+
+**Role in Robocode:** As an Achiever, you'll earn the most stars on your player card by scoring high in mini-games and coding challenges. Your path is about growth and visible accomplishment through targeted goals.
+
+**Fun Tips:**
+- Collect cool badges and level up
+- Set goals for yourself and celebrate when you hit them
+- Take on skill quests to show what you can do
+
+**Stages:** Ambition → Pursuit → Optimization → Recognition
+
+**Related Traits:** Planner, Go-Getter

--- a/content/robocode/player_profiles/competitor.md
+++ b/content/robocode/player_profiles/competitor.md
@@ -1,0 +1,25 @@
+---
+title: "Competitor 🔥"
+tags:
+  - robocode
+  - player-profile
+---
+
+# Competitor 🔥
+
+**Motivation:** Status, Prestige, Victory
+
+**Catchphrase:** "I want to win—and prove it."
+
+Competitors are achievement-oriented like achievers, but their focus is on *winning against others*. They enjoy leaderboards, ranked play, and opportunities to demonstrate superiority. A competitor's experience is heightened by real-time opposition and public recognition.
+
+**Role in Robocode:** As a Competitor, you focus on having the strongest bot in battle. Your code is optimized for tactical superiority, survival, and domination in the arena.
+
+**Fun Tips:**
+- Join tournaments to climb the leaderboard
+- Build winning strategies with friends
+- Show off your best moves for bragging rights
+
+**Stages:** Superiority → Tactical → Leadership → Legacy
+
+**Related Traits:** Leader, Prestige-Seeker

--- a/content/robocode/player_profiles/explorer.md
+++ b/content/robocode/player_profiles/explorer.md
@@ -1,0 +1,25 @@
+---
+title: "Explorer ✨"
+tags:
+  - robocode
+  - player-profile
+---
+
+# Explorer ✨
+
+**Motivation:** Autonomy, Curiosity, Discovery
+
+**Catchphrase:** "Let me wander and uncover the secrets."
+
+Explorers are driven by the joy of discovery. They thrive in environments where they can uncover hidden details, test systems, and experiment without strict time pressure. Their engagement comes from novelty and surprise rather than competition or external rewards.
+
+**Role in Robocode:** Everyone begins as an Explorer. You'll start by discovering how bots work and experimenting with movement, sensors, and code. This early phase sparks curiosity and lets you uncover strategies at your own pace.
+
+**Fun Tips:**
+- Search for hidden treasures and secret spots
+- Try out new moves—you never know what you'll find!
+- Keep exploring different paths to discover surprises
+
+**Stages:** Discovery → Trial → Occupation → Mentor
+
+**Related Traits:** Scientist, Technician

--- a/content/robocode/player_profiles/harmonizer.md
+++ b/content/robocode/player_profiles/harmonizer.md
@@ -1,0 +1,25 @@
+---
+title: "Harmonizer 🤝"
+tags:
+  - robocode
+  - player-profile
+---
+
+# Harmonizer 🤝
+
+**Motivation:** Belonging, Altruism, Support
+
+**Catchphrase:** "Let’s build something together."
+
+Harmonizers thrive on connection. They are the glue of any group, always looking to support and uplift others. Teamwork, empathy, and shared goals fuel their engagement. They flourish in cooperative settings and gain satisfaction from helping others succeed.
+
+**Role in Robocode:** As a Harmonizer, you help organize the competition. You might create fun chants for tanks, handle event commentary, design advertisements, and support the event's vibe. Your role boosts community spirit and cohesion. Harmonizers also set up the tournament using [start.gg](https://www.start.gg/) or their own system to keep everything running smoothly.
+
+**Fun Tips:**
+- Team up on group missions and help each other
+- Share cheers and keep everyone motivated
+- Teach your friends tricks and tips
+
+**Stages:** Connection → Partnership → Community → Impact
+
+**Related Traits:** Networker, Companion


### PR DESCRIPTION
## Summary
- add new `player_profiles` folder in Robocode
- document Explorer, Achiever, Competitor, and Harmonizer roles
- note that Harmonizers organize tournaments via start.gg or their own system

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c2f141f80832b9f622adcd7ca2bef