### PR TITLE
Fix Robocode Day 1 setup guide

### DIFF
--- a/content/robocode/Day-1/02_setting_up.md
+++ b/content/robocode/Day-1/02_setting_up.md
@@ -39,10 +39,9 @@ Download the ZIP file [from Google Drive](https://drive.google.com/file/d/1i6FZa
 
 
 ## Step 3: Verify the Setup
-
 - Open the Robocode application from the `robocode` folder.
-  - **Windows:** double-click `robocode.bat`.
-  - **macOS:** run `./robocode.sh` from Terminal or open `Robocode.app`.
+  - Launch it by running `robocode-tankroyale-gui`.
+- In the Robocode window, go to **Config → Bot Root Directories...** and select your `robots` folder.
 - Open the `robots` folder in your editor — it should contain a file like `MyFirstRobot.java`.
 - You're now ready to write your first robot logic!
 


### PR DESCRIPTION
## Summary
- clarify Robocode launch instructions and bot root configuration

## Testing
- `npm run check` *(fails: Cannot find module 'util' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686d708249e4832ba66e1a4e0653684d