### PR TITLE
Add Past Newsletters section

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -29,3 +29,7 @@ Explore the fundamentals of programming and combat AI using Robocode.
 ### 🏅 [EarthCraft Olympiad](/earthcraft_olympiad/) (WIP)
 
 A five-day camp of collaborative Minecraft competitions focused on ecology, energy, and economy.
+
+### 📰 [Past Newsletters](/past_newsletters/)
+
+Browse previous newsletter issues and track our journey.

--- a/content/past_newsletters/index.md
+++ b/content/past_newsletters/index.md
@@ -1,0 +1,10 @@
+---
+title: "Past Newsletters"
+tags:
+  - news
+  - contents
+---
+
+Welcome to our archive of past newsletters. Explore earlier issues to see how Infinite Mind has evolved over time.
+
+* [Newsletter #1](/past_newsletters/newsletter-1)

--- a/content/past_newsletters/newsletter-1.md
+++ b/content/past_newsletters/newsletter-1.md
@@ -1,0 +1,43 @@
+---
+title: "Newsletter #1"
+tags:
+  - news
+---
+
+Hi Stefan,
+
+VG has drafted an outline for creating evergreen marketing content. Here are the highlights from the first three courses we want to feature:
+
+## 1. Minecraft Movie Course – Make Your Own Film
+* **Format:** Group class, 8–12 sessions for ages 9–16
+* **What students do:** Conceptualize, script and film their own Minecraft movies
+* **Marketing focus:**
+  * Creative storytelling – kids become filmmakers
+  * Showcase student work with clips or screenshots
+  * Clearly communicate session lengths in promotions
+* **Newsletter snippet:**
+  > *Spotlight: Young Filmmakers in Action!* We just launched a short film by Maya (age 12) who wrote, directed and edited her own Minecraft adventure.
+
+## 2. Introduction to Java Programming with Robocode
+* **Format:** Hands‑on Java coding; students build robot tanks
+* **What students do:** Learn loops, methods and logic while battling their bots
+* **Marketing focus:**
+  * Gamified coding – learn Java by programming robots
+  * STEM and critical thinking benefits
+  * Share code snippets or battle screenshots
+* **Newsletter snippet:**
+  > *Tech Highlight: Meet Code‑Bot!* In our latest session, Max (age 13) debugged his algorithm mid‑battle and won!
+
+## 3. Sustainability Lab in Minecraft Java
+* **Format:** Five‑week group class for ages 8–13
+* **What students do:** Build a sustainable village using renewable energy
+* **Marketing focus:**
+  * Environmental education through play
+  * Collaborative building and community
+  * High ratings from past participants
+* **Newsletter snippet:**
+  > *Eco Spotlight: Building Green from the Ground Up.* Students picked solar, wind and hydro projects and brought them to life in their Minecraft biomes.
+
+VG also suggests a biweekly newsletter format rotating course spotlights, student showcases and upcoming sessions. The goal is to repurpose our videos and drive brand awareness for Infinite Mind.
+
+Please share any feedback or questions so we can refine future issues.

--- a/tags.md
+++ b/tags.md
@@ -33,6 +33,7 @@ Use this table to standardize tags across your Quartz-based lab content. You can
 |                      | `contents`       | Table of contents or structured index for a section         |
 |                      | `story`       | Table of contents or structured index for a section            |
 |                      | `tutorial`       | Step-by-step instructional content                          |
+|                      | `news`           | Past newsletters and updates                              |
 | Category             | `sustainability` | Focus on sustainable energy                                 |
 |                      | `programming` | Focus on learning programming                               |
 |                      | `arts`           | Focus on creative arts projects |


### PR DESCRIPTION
## Summary
- create `past_newsletters` folder with newsletter #1
- add link on home page to the newsletter archive
- update tag reference table with a new `news` tag

## Testing
- `npm run check` *(fails: Cannot find module 'source-map-support' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687151586030832b86064d15a2104772