### PR TITLE
Remove page title text from header

### DIFF
--- a/quartz/components/PageTitle.tsx
+++ b/quartz/components/PageTitle.tsx
@@ -1,10 +1,10 @@
 import { pathToRoot } from "../util/path"
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import { classNames } from "../util/lang"
-import { i18n } from "../i18n"
+// import { i18n } from "../i18n"
 
 const PageTitle: QuartzComponent = ({ fileData, cfg, displayClass }: QuartzComponentProps) => {
-  const title = cfg?.pageTitle ?? i18n(cfg.locale).propertyDefaults.title
+  // const title = cfg?.pageTitle ?? i18n(cfg.locale).propertyDefaults.title
   const baseDir = pathToRoot(fileData.slug!)
   const siteBase = cfg.baseUrl ? new URL(`https://${cfg.baseUrl}`).pathname : ""
   const defaultIcon = `${siteBase}/images/low/icon2_white.webp`
@@ -30,7 +30,7 @@ const PageTitle: QuartzComponent = ({ fileData, cfg, displayClass }: QuartzCompo
     <h2 class={classNames(displayClass, "page-title")}>
       <a href={baseDir} class="page-title-link">
         <img src={defaultIcon} alt="Home Icon" class="page-title-icon" />
-        <span class="page-title-text">{title}</span>
+        {/* <span class="page-title-text">{title}</span> */}
       </a>
       <script dangerouslySetInnerHTML={{ __html: clientScript }} />
     </h2>
@@ -47,7 +47,7 @@ PageTitle.css = `
 .page-title-link {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  /* gap: 0.5rem; */
   text-decoration: none;
   color: inherit;
 }
@@ -57,14 +57,14 @@ PageTitle.css = `
   height: 8rem;
 }
 
-.page-title-text {
+/* .page-title-text {
   display: inline;
-}
+} */
 
 @media (max-width: 600px) {
-  .page-title-text {
+  /* .page-title-text {
     display: none;
-  }
+  } */
   .page-title-icon {
     width: 3rem;
     height: 3rem;


### PR DESCRIPTION
## Summary
- comment out site title span and related logic so only logo renders in `PageTitle`

## Testing
- `npm test` *(fails: sh: 1: tsx: not found)*
- `npm run check` *(fails: TypeScript errors for many files)*
- `npx quartz build` *(fails: Unsupported engine, requires Node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68913560f758832b9a391036c9981a6f