### PR TITLE
Add Robocode Day 1 setup troubleshooting guide

### DIFF
--- a/content/robocode/Day-1/02_setting_up.md
+++ b/content/robocode/Day-1/02_setting_up.md
@@ -22,9 +22,7 @@ Download the ZIP file [from Google Drive](https://drive.google.com/file/d/1i6FZa
 - A workspace folder
 - A starter Java robot template
 
-
 <img src="/images/low/robocode/robocode_zip_file.webp" alt="robocode file view" style="border-radius: 12px; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);">
-
 
 > 📦 If you haven't received the ZIP, ask your instructor or team lead.
 
@@ -37,18 +35,19 @@ Download the ZIP file [from Google Drive](https://drive.google.com/file/d/1i6FZa
 3. Open your VS Code.
 4. Use **File → Open Folder** and select the `RoboCode/robots/MyFirstRobot` directory on your desktop.
 
-
 ## Step 3: Verify the Setup
+
 - Open the Robocode application from the `robocode` folder.
   - Launch it by running `robocode-tankroyale-gui`.
 - In the Robocode window, go to **Config → Bot Root Directories...** and select your `robots` folder.
 - Open the `robots` folder in your editor — it should contain a file like `MyFirstRobot.java`.
 - You're now ready to write your first robot logic!
 
----
+> Having trouble? Check the [Setup Troubleshooting](/robocode/Day-1/setup_troubleshooting) guide.
 
+---
 
 ## Navigation
 
 ⬅️ [Back: Setup with VS Code](/robocode/Day-1/01_setup_vscode)
-➡️ [Next: Hello World Program](/robocode/Day-1/03_hello_world)
+➡️ [Next: Setup Troubleshooting](/robocode/Day-1/setup_troubleshooting)

--- a/content/robocode/Day-1/index.md
+++ b/content/robocode/Day-1/index.md
@@ -9,23 +9,25 @@ tags:
 
 ## Lesson Requirements
 
-* Install the latest **Java JDK** so you can compile code
-* Download **Visual Studio Code** with the Java extension pack
-* Setup the robocode program
-* Steps below include notes for **Windows** and **macOS** users
+- Install the latest **Java JDK** so you can compile code
+- Download **Visual Studio Code** with the Java extension pack
+- Setup the robocode program
+- Steps below include notes for **Windows** and **macOS** users
 
 ## Lesson Outcomes
 
-* Launch Robocode and confirm it loads your robot
-* Run a "Hello World" program in VS Code
-* Understand how to compile and run Java files from the editor
+- Launch Robocode and confirm it loads your robot
+- Run a "Hello World" program in VS Code
+- Understand how to compile and run Java files from the editor
 
 > **Note:** In Java, lines that begin with `//` are comments. They are there for humans and are not executed as code.
 
 > Gear up for **Day 1** 😀
+
 - [Introductions](/robocode/Day-1/introductions)
 - [Outline](/robocode/Day-1/00_java_intro)
 - [Setup with VS Code](/robocode/Day-1/01_setup_vscode)
 - [Setting Up Robocode](/robocode/Day-1/02_setting_up)
+- [Setup Troubleshooting](/robocode/Day-1/setup_troubleshooting)
 - [Hello World Program](/robocode/Day-1/03_hello_world)
 - [Player Profiles](/robocode/Day-1/04_player_profiles)

--- a/content/robocode/Day-1/setup_troubleshooting.md
+++ b/content/robocode/Day-1/setup_troubleshooting.md
@@ -1,0 +1,44 @@
+---
+title: "Setup Troubleshooting"
+tags:
+  - robocode
+  - tutorial
+  - cs
+  - beginner
+  - troubleshooting
+---
+
+> 🤔 Having trouble getting Robocode running? Use this guide to solve common setup issues.
+
+## Robocode won't launch
+
+- **Issue:** Double-clicking the app does nothing.
+  **Fix:** Make sure the downloaded folder is fully extracted. On macOS, right-click and choose _Open_ the first time to bypass security prompts.
+
+## "java" or "javac" not found
+
+- **Issue:** Terminal says `command not found`.
+  **Fix:** Confirm the JDK is installed and in your PATH.
+  - **Windows:** Open Command Prompt and run `where java`. If it reports nothing, reinstall the JDK and check "Set JAVA_HOME".
+  - **macOS:** Run `/usr/libexec/java_home` in Terminal to verify. If missing, reinstall using `brew install temurin`.
+
+## VS Code can't find the JDK
+
+- **Issue:** Java files show errors or the Run button is missing.
+  **Fix:** Install the **Extension Pack for Java** and restart VS Code. If problems persist, press `Ctrl+Shift+P`, search for _Java: Configure Java Runtime_, and ensure the JDK path points to your installation.
+
+## Robocode can't see your robot
+
+- **Issue:** Robocode opens but no robots appear.
+  **Fix:** In Robocode go to **Config → Bot Root Directories…** and select the `robots` folder inside your project. Save and reopen the Battle view.
+
+## Still stuck?
+
+Ask an instructor or teammate for help — there's usually a quick fix!
+
+---
+
+## Navigation
+
+⬅️ [Back: Setting Up Robocode](/robocode/Day-1/02_setting_up)
+➡️ [Next: Hello World Program](/robocode/Day-1/03_hello_world)


### PR DESCRIPTION
## Summary
- document common setup issues for Robocode Day 1
- link troubleshooting page from Day 1 index and setup steps

## Testing
- `npm run check` (warnings: Code style issues found in 99 files)
- `npx quartz build` (failed: Failed to emit from plugin `CustomOgImages`: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_689259b1666c832baec79e60c14abe89