### PR TITLE
docs: add mac and windows java version fix for robocode

### DIFF
--- a/content/robocode/Day-1/setup_troubleshooting.md
+++ b/content/robocode/Day-1/setup_troubleshooting.md
@@ -14,6 +14,24 @@ tags:
 
 - **Issue:** Double-clicking the app does nothing.
   **Fix:** Make sure the downloaded folder is fully extracted. On macOS, right-click and choose _Open_ the first time to bypass security prompts.
+- **Issue:** Robocode GUI won't open due to an incorrect Java version.
+  **Fix:** Point to Java 21 before launching Robocode:
+
+  **macOS**
+
+  ```bash
+  export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+  export PATH=$JAVA_HOME/bin:$PATH
+  ```
+
+  **Windows**
+
+  ```cmd
+  set "JAVA_HOME=C:\Program Files\Java\jdk-21"
+  set "PATH=%JAVA_HOME%\bin;%PATH%"
+  ```
+
+  These commands temporarily use the correct JDK for the current session.
 
 ## "java" or "javac" not found
 


### PR DESCRIPTION
## Summary
- document macOS and Windows environment fixes for Robocode when wrong Java version prevents GUI launch

## Testing
- `npm run check` (fails: Cannot find module 'util' or its corresponding type declarations)
- `npx quartz build` (fails: Not compatible with your version of node/npm: @jackyzha0/quartz@4.5.1)


------
https://chatgpt.com/codex/tasks/task_e_689277e56494832baa657db01221d4d3