### PR TITLE
Use classic free-for-all format for Robocode tournament

### DIFF
--- a/content/robocode/Day-10/00_tournament_overview.md
+++ b/content/robocode/Day-10/00_tournament_overview.md
@@ -15,7 +15,7 @@ tags:
 - Celebrate through a friendly competition.
 - Showcase unique robot designs and strategies.
 
-We'll run a [round-robin tournament](/robocode/tournament_format) where every student battles each other once. At the end, mark the top three finishers on each player's tank card with **1**, **2**, or **3**.
+We'll run a [classic free-for-all tournament](/robocode/tournament_format) where every student battles together in the same arena. At the end, mark the top three finishers on each player's tank card with **1**, **2**, or **3**.
 
 ⬅️ [Back: Day 9](/robocode/Day-9/index)
 ➡️ [Next: Peer Assessment](/robocode/Day-10/01_peer_reflection)

--- a/content/robocode/Day-5/00_tournament_overview.md
+++ b/content/robocode/Day-5/00_tournament_overview.md
@@ -15,7 +15,7 @@ tags:
 - Celebrate through a friendly competition.
 - Showcase unique robot designs and strategies.
 
-We'll run a [round-robin tournament](/robocode/tournament_format) where every student battles each other once. Mark the top three finishers on each player's tank card with **1**, **2**, or **3**.
+We'll run a [classic free-for-all tournament](/robocode/tournament_format) where every student battles together in the same arena. Mark the top three finishers on each player's tank card with **1**, **2**, or **3**.
 
 ⬅️ [Back: Day 4](/robocode/Day-4/index)
 ➡️ [Next: Peer Assessment](/robocode/Day-5/01_peer_reflection)

--- a/content/robocode/tournament_format.md
+++ b/content/robocode/tournament_format.md
@@ -8,38 +8,23 @@ tags:
 ---
 
 > Buckle up for **Tournament Format** 🤖
-# Robocode 1 vs 1 Tournament
+# Robocode Free-for-All Tournament
 
-At the end of the week, we host a **round-robin** style tournament where every student competes against every other student. Each participant enters their custom robot, and matches are played to determine a final leaderboard.
+At the end of the week, we host a tournament using Robocode's **Classic** mode. Every student loads their custom robot into the same arena and battles simultaneously in a free-for-all showdown.
 
 ## Format
 
-* **Round Robin:** Every robot battles every other robot once.
-* Matches are **1 vs 1**.
-* Each match consists of a **best of three** battles.
-* Players earn **1 point per match win**.
-* The instructor's bot also competes in the round robin. Can you defeat it?
+* **Classic Mode:** All robots fight at once.
+* Play a **set of battles** (e.g., best of three) to smooth out randomness.
+* Players earn **points for each battle win**.
+* The instructor's bot joins the chaos. Can you defeat it?
 
-At the end of all rounds, the bots are ranked by total points. Ties may be broken using head-to-head results or an extra tie-breaker match.
-
-## Example Schedule
-
-| Match | Competitors             |
-| ----- | ----------------------- |
-| 1     | Student A vs B          |
-| 2     | Student A vs C          |
-| 3     | Student B vs C          |
-| 4     | Student A vs Instructor |
-| 5     | Student B vs Instructor |
-| 6     | Student C vs Instructor |
-
-This continues until all matchups have been played.
+After all battles, bots are ranked by total points. Ties may be broken with an extra battle.
 
 ## Rules
 
-* Matches are **1 vs 1**.
-* Each round is the **best of three** battles.
+* Battles use Robocode's **classic free-for-all** settings.
+* Last robot standing wins the battle.
 * Total points determine final standings.
 
 Good luck, and may the best code win!
-


### PR DESCRIPTION
## Summary
- Update robocode tournament guide to use classic mode free-for-all instead of round robin 1v1
- Adjust Day 5 and Day 10 overviews to reference the new free-for-all tournament format

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: missing modules / type definitions)*
- `npx quartz build` *(fails: requires node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_68963deb388c832b99637bf5849ac45e