### PR TITLE
Clarify player card JSON instructions for Robocode

### DIFF
--- a/content/robocode/Day-10/03_player_card.md
+++ b/content/robocode/Day-10/03_player_card.md
@@ -13,6 +13,11 @@ tags:
 
 Use the [player card generator](https://docs.google.com/forms/d/e/1FAIpQLSeO3NAcXqPCaacO21ZvApGUHdzv9Nuon2acvDtka6GBHQW6Hw/viewform?usp=header) to design your card.
 
+Open your robot's `.json` descriptor file (for example, `MyFirstBot.json`).
+Select all of the text (`Ctrl+A`, `Ctrl+C`) and paste those contents into the
+generator when prompted. Be sure you're copying the contents of the file, not
+the file itself.
+
 ## Capture a Screenshot
 
 Use the Windows **Snipping Tool** to grab a clean shot of your bot during a battle:

--- a/content/robocode/Day-5/03_player_card.md
+++ b/content/robocode/Day-5/03_player_card.md
@@ -13,6 +13,11 @@ tags:
 
 Use the [player card generator](https://docs.google.com/forms/d/e/1FAIpQLSeO3NAcXqPCaacO21ZvApGUHdzv9Nuon2acvDtka6GBHQW6Hw/viewform?usp=header) to design your card.
 
+Open your robot's `.json` descriptor file (for example, `MyFirstBot.json`).
+Select all of the text (`Ctrl+A`, `Ctrl+C`) and paste those contents into the
+generator when prompted. Be sure you're copying the contents of the file, not
+the file itself.
+
 ## Capture a Screenshot
 
 Use the Windows **Snipping Tool** to grab a clean shot of your bot during a battle:


### PR DESCRIPTION
## Summary
- Clarify that creating player cards requires copying the JSON file contents into the generator

## Testing
- `npm run check` *(fails: Cannot find modules and JSX runtime)*
- `npx quartz build` *(fails: Unsupported engine; requires Node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_6896472ab400832b843f954e469a51dc