### PR TITLE
docs: update Day 4 Robocode references to ScannedBotEvent

### DIFF
--- a/content/robocode/Day-4/index.md
+++ b/content/robocode/Day-4/index.md
@@ -16,11 +16,11 @@ tags:
 ## Lesson Outcomes
 
 * Print debug messages with `System.out.println`
-* React to `ScannedRobotEvent` and `HitByBulletEvent`
+* React to `ScannedBotEvent` and `HitByBulletEvent`
 * Use console output to tune your robot's behavior
 
 > Get pumped for **Day 4** 😎
 - [VS Code Autocomplete Setup](/robocode/Day-4/00_vscode_api_setup)
 - [System.out.println for Debugging](/robocode/Day-4/01_system_out_debugging)
-- [ScannedRobotEvent](/robocode/Day-4/02_scanned_robot_event)
+- [ScannedBotEvent](/robocode/Day-4/02_scanned_robot_event)
 - [HitByBulletEvent](/robocode/Day-4/03_hit_by_bullet_event)


### PR DESCRIPTION
## Summary
- update Day 4 lesson outcome to mention `ScannedBotEvent`
- update navigation entry to `ScannedBotEvent` and remove remaining `ScannedRobotEvent` references

## Testing
- `npm run check` *(fails: Cannot find module 'preact/jsx-runtime' and other type declarations)*
- `npx quartz build` *(fails: engine Unsupported engine for @jackyzha0/quartz@4.5.1)*

------
https://chatgpt.com/codex/tasks/task_e_689785c1369c832bb64da3a04624d412