### PR TITLE
fix event reference in robocode overview

### DIFF
--- a/content/robocode/index.md
+++ b/content/robocode/index.md
@@ -73,7 +73,7 @@ Finale: A **Robocode tournament** with a focus on **kindness**, **peer feedback*
 
 ### [🌀 Day 4: Events & Output](/robocode/Day-4/)
 
-- React to `ScannedRobotEvent`, `HitByBulletEvent`
+- React to `ScannedBotEvent`, `HitByBulletEvent`
 - Use print statements as narrative tools
 - Celebrate every bug as a clue
 


### PR DESCRIPTION
## Summary
- fix Day 4 bullet to mention `ScannedBotEvent`

## Testing
- `npm test`
- `npm run check` *(fails: Code style issues found in 99 files)*
- `npx quartz build` *(fails: Failed to emit from plugin `CustomOgImages`: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689785d68130832badd13e90964387fa