### PR TITLE
docs: reference latest Robocode API jar

### DIFF
--- a/content/robocode/Day-4/00_vscode_api_setup.md
+++ b/content/robocode/Day-4/00_vscode_api_setup.md
@@ -12,7 +12,7 @@ tags:
 
 ## Copy the API JAR
 
-1. Find `robocode-tankroyale-bot-api-0.31.0.jar` in your downloaded Robocode folder.
+1. Find the Robocode API JAR (e.g., `robocode-tankroyale-bot-api-0.32.1.jar`) in your downloaded Robocode folder. Look for `robocode-tankroyale-bot-api-<version>.jar` to use the latest version.
 2. Copy it into the root of your robot project.
 
 ## Configure VS Code


### PR DESCRIPTION
## Summary
- mention the latest `robocode-tankroyale-bot-api-0.32.1.jar` and use a `<version>` placeholder

## Testing
- `npm run check` *(fails: Code style issues found in 99 files)*
- `npx quartz build` *(fails: CustomOgImages plugin fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689785c2fbb4832bb94a8f48e5a47560