### PR TITLE
docs: streamline robocode api setup

### DIFF
--- a/content/robocode/Day-4/00_vscode_api_setup.md
+++ b/content/robocode/Day-4/00_vscode_api_setup.md
@@ -10,11 +10,6 @@ tags:
 
 > Kick off Day 4 by configuring **Robocode API** autocomplete in VS Code.
 
-## Copy the API JAR
-
-1. Find the Robocode API JAR (e.g., `robocode-tankroyale-bot-api-0.32.1.jar`) in your downloaded Robocode folder. Look for `robocode-tankroyale-bot-api-<version>.jar` to use the latest version.
-2. Copy it into the root of your robot project.
-
 ## Configure VS Code
 
 1. Inside your project, create a folder named `.vscode`.
@@ -24,12 +19,14 @@ tags:
 ```json
 {
     "java.project.referencedLibraries": [
-        "*.jar"
+        "../lib/*.jar"
     ]
 }
 ```
 
-This tells VS Code to load any JAR in your project so IntelliSense can use the Robocode API.
+This tells VS Code to load any JAR stored in a sibling `lib` folder so IntelliSense can use the Robocode API without moving files into your project.
+
+If you keep the JAR in your project root instead, replace `../lib/*.jar` with `*.jar`.
 
 ---
 


### PR DESCRIPTION
## Summary
- remove instructions to copy the Robocode API JAR
- show VS Code settings that reference external JARs

## Testing
- `npm test` *(fails: tsx: not found due to unmet Node 22 requirement)*
- `npm run check` *(fails: missing JSX/Node types; dependencies not installed)*
- `npx quartz build` *(fails: unsupported Node version requirement)*

------
https://chatgpt.com/codex/tasks/task_e_689a6bdf7d68832bbc59b76b0eaf9010