### PR TITLE
Add HitWall event lesson to Day 4

### DIFF
--- a/content/robocode/Day-4/03_hit_by_bullet_event.md
+++ b/content/robocode/Day-4/03_hit_by_bullet_event.md
@@ -55,4 +55,4 @@ But for now, this two‑line dodge keeps things simple and fun.
 ## Navigation
 
 ⬅️ [Back: ScannedBotEvent](/robocode/Day-4/02_scanned_bot_event)
-➡️ [Next: Day 5](/robocode/Day-5/index)
+➡️ [Next: HitWallEvent](/robocode/Day-4/05_hit_wall_event)

--- a/content/robocode/Day-4/05_hit_wall_event.md
+++ b/content/robocode/Day-4/05_hit_wall_event.md
@@ -1,0 +1,44 @@
+---
+title: "5 - HitWallEvent"
+tags:
+  - robocode
+  - tutorial
+  - hands-on
+  - cs
+  - intermediate
+---
+
+## 5 – Bounce Off the Walls
+
+When your robot collides with the arena boundary, the `onHitWall` method runs.
+
+### What happens?
+
+- Robocode alerts your bot that it hit a wall.
+- We'll turn around and drive away to stay in the fight.
+
+### Code
+
+```java
+@Override
+public void onHitWall(HitWallEvent botHitWallEvent) {
+    // 1. Turn 180° away from the wall
+    turnRight(180);
+    // 2. Move forward to escape
+    forward(100);
+}
+```
+
+### Parameters
+
+- `botHitWallEvent` – event details from the game.
+
+### Why it works
+
+- Turning around keeps your bot from getting stuck.
+- Moving forward puts space between you and the wall.
+
+## Navigation
+
+⬅️ [Back: HitByBulletEvent](/robocode/Day-4/03_hit_by_bullet_event)
+➡️ [Next: Day 5](/robocode/Day-5/index)

--- a/content/robocode/Day-4/index.md
+++ b/content/robocode/Day-4/index.md
@@ -16,7 +16,7 @@ tags:
 ## Lesson Outcomes
 
 * Print debug messages with `System.out.println`
-* React to `ScannedBotEvent` and `HitByBulletEvent`
+* React to `ScannedBotEvent`, `HitByBulletEvent`, and `HitWallEvent`
 * Use console output to tune your robot's behavior
 
 > Get pumped for **Day 4** 😎
@@ -24,3 +24,4 @@ tags:
 - [System.out.println for Debugging](/robocode/Day-4/01_system_out_debugging)
 - [ScannedBotEvent](/robocode/Day-4/02_scanned_bot_event)
 - [HitByBulletEvent](/robocode/Day-4/03_hit_by_bullet_event)
+- [HitWallEvent](/robocode/Day-4/05_hit_wall_event)


### PR DESCRIPTION
## Summary
- Document how to handle Robocode's `onHitWall` event and recover after colliding with arena walls
- Note new lesson in Day 4 index and link from HitByBulletEvent

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: missing modules)*
- `npx quartz build` *(fails: unsupported engine)*

------
https://chatgpt.com/codex/tasks/task_e_689cf5246e50832b8ea1a3d231863d16