### PR TITLE
Remove kid-friendly phrasing from Day 8 flowchart

### DIFF
--- a/content/robocode/Day-8/00_hit_reaction_plan.md
+++ b/content/robocode/Day-8/00_hit_reaction_plan.md
@@ -18,7 +18,7 @@ Before you write a single line of code, it helps to map out what your robot will
 
 # 🚦 Simple Event Flow – **Robocode Tank Royale** Bot
 
-This kid‑friendly flowchart shows **what happens each game tick**. In Tank Royale the game engine automatically calls the three event methods *first*. If none of them fire, your `run()` code is the **fallback** that keeps your bot moving and scanning.
+This flowchart shows **what happens each game tick**. In Tank Royale the game engine automatically calls the three event methods *first*. If none of them fire, your `run()` code is the **fallback** that keeps your bot moving and scanning.
 
 * **`onScannedBot(ScannedBotEvent e)`** – you spotted an opponent.
 * **`onHitByBullet(HitByBulletEvent e)`** – you were hit by a bullet.


### PR DESCRIPTION
## Summary
- remove "kid-friendly" wording from Robocode Day 8 hit reaction plan

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: missing modules)*
- `npx quartz build` *(fails: incompatible Node/npm)*

------
https://chatgpt.com/codex/tasks/task_e_689cd7c26a94832baa01b033db88ec58