### PR TITLE
feat: adjust Day 4 wall collision action

### DIFF
--- a/content/robocode/Day-4/01_system_out_debugging.md
+++ b/content/robocode/Day-4/01_system_out_debugging.md
@@ -80,7 +80,8 @@ public class DebugBot extends Bot {
     @Override
     public void onHitWall(HitWallEvent e) {
         System.out.println(name + " hit a wall");
-        back(100);
+        turnLeft(180);
+        forward(100);
     }
 ```
 

--- a/content/robocode/Day-4/05_hit_wall_event.md
+++ b/content/robocode/Day-4/05_hit_wall_event.md
@@ -22,8 +22,8 @@ When your robot collides with the arena boundary, the `onHitWall` method runs.
 ```java
 @Override
 public void onHitWall(HitWallEvent botHitWallEvent) {
-    // 1. Turn 180° away from the wall
-    turnRight(180);
+    // 1. Turn left 180° away from the wall
+    turnLeft(180);
     // 2. Move forward to escape
     forward(100);
 }


### PR DESCRIPTION
## Summary
- Turn left instead of right when bots hit a wall in Day 4 tutorial
- Update debugging snippet to demonstrate left turn and forward escape

## Testing
- `npm run check` *(fails: Cannot find module 'util' or its corresponding type declarations)*
- `npx quartz build` *(fails: Unsupported engine for @jackyzha0/quartz@4.5.1)*

------
https://chatgpt.com/codex/tasks/task_e_689d0c9c0e00832b8ef6954328eb4597