### PR TITLE
Use 'opponent' in Day 4 Robocode docs

### DIFF
--- a/content/robocode/Day-4/02_scanned_bot_event.md
+++ b/content/robocode/Day-4/02_scanned_bot_event.md
@@ -19,7 +19,7 @@ tags:
 
 ### What it Does
 
-This method is called when your robot sees another robot — i.e., when your radar scan "hits" another robot. You must override this method if you want your robot to respond to nearby enemies.
+This method is called when your robot sees another robot — i.e., when your radar scan "hits" another robot. You must override this method if you want your robot to respond to nearby opponents.
 
 
 The **bearing** you receive is *relative* to your robot's current heading.
@@ -52,22 +52,22 @@ public void onScannedBot(ScannedBotEvent event)
 ```java
 @Override
 public void onScannedBot(ScannedBotEvent event) {
-    // 1. Remember where the enemy is
-    double enemyX = event.getX();  // Enemy's X position
-    double enemyY = event.getY();  // Enemy's Y position
+    // 1. Remember where the opponent is
+    double opponentX = event.getX();  // Opponent's X position
+    double opponentY = event.getY();  // Opponent's Y position
 
     // 2. Remember where *we* are
     double myX = getX();           // My bot's X position
     double myY = getY();           // My bot's Y position
 
     // 3. Find the distance between us
-    double dx = enemyX - myX;      // How far apart we are in X
-    double dy = enemyY - myY;      // How far apart we are in Y
+    double dx = opponentX - myX;      // How far apart we are in X
+    double dy = opponentY - myY;      // How far apart we are in Y
 
     // 4. Use the Pythagorean theorem to get the total distance
     double distance = Math.sqrt(dx * dx + dy * dy);
 
-    System.out.println("Enemy detected at: " + distance + " pixels");
+    System.out.println("Opponent detected at: " + distance + " pixels");
 
     // Fire with stronger power if close, weaker if far
     if (distance < 100) {
@@ -81,7 +81,7 @@ public void onScannedBot(ScannedBotEvent event) {
 
 ### Summary:
 
-* Override `onScannedBot` to react to enemies.
+* Override `onScannedBot` to react to opponents.
 * Use the data in `ScannedBotEvent` to decide when and how to fire.
 
 ---

--- a/content/robocode/Day-4/04_minigame.md
+++ b/content/robocode/Day-4/04_minigame.md
@@ -33,11 +33,11 @@ Use this guide to understand the colored dots on PlayerBot’s on‑screen compa
 | Dot Colour    | Meaning                                                                                                               |
 | ------------- | --------------------------------------------------------------------------------------------------------------------- |
 | 🔴 **Red**    | Opponent’s **current** location (shown right after a scan).                                                           |
-| 🟡 **Yellow** | Opponent’s **previous** location. The red dot turns yellow once the enemy moves, so you can see where they were last. |
+| 🟡 **Yellow** | Opponent’s **previous** location. The red dot turns yellow once the opponent moves, so you can see where they were last. |
 | 🔵 **Blue**   | Direction your **gun turret** is pointing.                                                                            |
 | 🟢 **Green**  | Direction your **tank body** is pointing.                                                                             |
 
-Keep an eye on how the red dot switches to yellow—this tells you the enemy has changed position since your last scan.
+Keep an eye on how the red dot switches to yellow—this tells you the opponent has changed position since your last scan.
 
 ---
 
@@ -145,7 +145,7 @@ Use these keys to drive:
 - `E` – Rotate turret clockwise
 - `Space` – Fire!
 
-> Try spinning in place, dodging bullets, or chasing down an enemy.
+> Try spinning in place, dodging bullets, or chasing down an opponent.
 
 ---
 
@@ -164,7 +164,7 @@ Use this play session to explore how the basic physics and rules of Robocode wor
 
 See if you can:
 
-- Hit a moving enemy
+- Hit a moving opponent
 - Dodge incoming fire
 - Defeat "Target" in a 1v1 match
 


### PR DESCRIPTION
## Summary
- Replace references to "enemy" with "opponent" in Day 4 Robocode lessons
- Update example code to use `opponent` variables

## Testing
- `npm test` *(fails: tsx: not found)*
- `npm run check` *(fails: missing modules / typings)*
- `npx quartz build` *(fails: requires Node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_689d1dac6f64832b955bb705e1221439