### PR TITLE
Clarify set* movement method usage in Robocode lesson

### DIFF
--- a/content/robocode/Day-11+/01_movement_patterns.md
+++ b/content/robocode/Day-11+/01_movement_patterns.md
@@ -8,6 +8,8 @@ tags:
   - intermediate
 ---
 
+The `set*` movement methods like `setTurnLeft`, `setTurnRight`, `setForward`, and `setBack` queue actions to run on the next turn. Call them from your `run()` loop or an event handler such as `onScannedRobot` so your bot can turn and move in the same tick.
+
 > Smart movement keeps your bot alive.
 
 Try mixing circles and zigzags to dodge bullets:


### PR DESCRIPTION
## Summary
- move explanation of set* movement methods to the start of the Movement Patterns lesson
- mention setTurnLeft/setTurnRight and setForward/setBack usage

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: missing modules and type errors)*
- `npx quartz build` *(fails: Node >=22 required)*

------
https://chatgpt.com/codex/tasks/task_e_689e27f14de0832babe9119b4eb13e16