### PR TITLE
feat: place progress checklists at end of robocode days

### DIFF
--- a/content/robocode/Day-1/index.md
+++ b/content/robocode/Day-1/index.md
@@ -31,3 +31,4 @@ tags:
 - [Setup Troubleshooting](/robocode/Day-1/setup_troubleshooting)
 - [Hello World Program](/robocode/Day-1/03_hello_world)
 - [Player Profiles](/robocode/Day-1/04_player_profiles)
+- [Minigame](/robocode/Day-1/05_minigame)

--- a/content/robocode/Day-2/index.md
+++ b/content/robocode/Day-2/index.md
@@ -24,5 +24,5 @@ tags:
 - [Outline](/robocode/Day-2/00_robocode_intro)
 - [First Lines of Code](/robocode/Day-2/02_first_lines)
 - [Robocode Geometry](/robocode/Day-2/03_geometry)
-- [Minigame](/robocode/Day-2/04_minigame)
 - [Tank Colors](/robocode/Day-2/04_color_and_profiles)
+- [Minigame](/robocode/Day-2/04_minigame)

--- a/content/robocode/Day-3/index.md
+++ b/content/robocode/Day-3/index.md
@@ -22,3 +22,4 @@ tags:
 > Ready to dive into **Day 3** 😎
 - [Variables and Datatypes](/robocode/Day-3/00_variables_and_datatypes)
 - [Data Type Examples](/robocode/Day-3/01_datatype_examples)
+- [Minigame](/robocode/Day-3/02_minigame)

--- a/content/robocode/Day-4/index.md
+++ b/content/robocode/Day-4/index.md
@@ -25,3 +25,4 @@ tags:
 - [ScannedBotEvent](/robocode/Day-4/02_scanned_bot_event)
 - [HitByBulletEvent](/robocode/Day-4/03_hit_by_bullet_event)
 - [HitWallEvent](/robocode/Day-4/05_hit_wall_event)
+- [Minigame](/robocode/Day-4/04_minigame)

--- a/content/robocode/Day-6/04_reactionary_logic.md
+++ b/content/robocode/Day-6/04_reactionary_logic.md
@@ -77,5 +77,3 @@ public class ReactiveBot extends Bot {
 ⬅️ [Back: Loops](/robocode/Day-6/03_loops)
 ➡️ [Next: Variable Scope](/robocode/Day-6/05_variable_scope)
 
-<iframe src="https://axyl-casc.github.io/WikiMinigames/checklist.html"
-  style="width: 100%; height: 100%; min-height: 600px; border: none; border-radius: 8px;"></iframe>

--- a/content/robocode/Day-6/05_variable_scope.md
+++ b/content/robocode/Day-6/05_variable_scope.md
@@ -83,3 +83,6 @@ for (int i = 0; i < 3; i++) {
 
 ⬅️ [Back: Reactionary Logic](/robocode/Day-6/04_reactionary_logic)
 ➡️ [Next: Day 7](/robocode/Day-7/index)
+
+<iframe src="https://axyl-casc.github.io/WikiMinigames/checklist.html"
+  style="width: 100%; height: 100%; min-height: 600px; border: none; border-radius: 8px;"></iframe>

--- a/content/robocode/Day-7/04_ownership_naming.md
+++ b/content/robocode/Day-7/04_ownership_naming.md
@@ -89,5 +89,3 @@ int bullet_count = 3;
 ⬅️ [Back: Helper Methods](/robocode/Day-7/03_helper_methods)
 ➡️ [Next: Day 8](/robocode/Day-8/index)
 
-<iframe src="https://axyl-casc.github.io/WikiMinigames/checklist.html"
-  style="width: 100%; height: 100%; min-height: 600px; border: none; border-radius: 8px;"></iframe>

--- a/content/robocode/Day-7/review.md
+++ b/content/robocode/Day-7/review.md
@@ -36,3 +36,6 @@ Use these questions to guide your notes and plan what to tackle next.
 
 ⬅️ [Back: Ownership & Naming](/robocode/Day-7/04_ownership_naming)
 ➡️ [Next: Day 8](/robocode/Day-8/index)
+
+<iframe src="https://axyl-casc.github.io/WikiMinigames/checklist.html"
+  style="width: 100%; height: 100%; min-height: 600px; border: none; border-radius: 8px;"></iframe>

--- a/content/robocode/Day-9/01_sweeping_left_right.md
+++ b/content/robocode/Day-9/01_sweeping_left_right.md
@@ -55,7 +55,5 @@ public boolean findTarget(Bot bot) {
 ## Navigation
 
 ⬅️ [Back: Build Day Agenda](/robocode/Day-9/00_build_showcase)
-➡️ [Next: Day 10](/robocode/Day-10/index)
+➡️ [Next: Robocode BaseBot API JavaDocs](/robocode/Day-9/02_robocode_javadocs)
 
-<iframe src="https://axyl-casc.github.io/WikiMinigames/checklist.html"
-  style="width: 100%; height: 100%; min-height: 600px; border: none; border-radius: 8px;"></iframe>

--- a/content/robocode/Day-9/02_robocode_javadocs.md
+++ b/content/robocode/Day-9/02_robocode_javadocs.md
@@ -14,3 +14,11 @@ JavaDocs are the official documentation generated from Java source code comments
 Robocode Tank Royale provides a `BaseBot` class that your robot extends. Its JavaDocs detail everything your bot can do, including movement, event handling, and utilities. Review the [BaseBot API documentation](https://robocode-dev.github.io/tank-royale/api/java/dev/robocode/tankroyale/botapi/BaseBot.html) while developing your robot.
 
 Use these JavaDocs as a reference when implementing features in your robot.
+
+## Navigation
+
+⬅️ [Back: Sweeping Left & Right](/robocode/Day-9/01_sweeping_left_right)
+➡️ [Next: Day 10](/robocode/Day-10/index)
+
+<iframe src="https://axyl-casc.github.io/WikiMinigames/checklist.html"
+  style="width: 100%; height: 100%; min-height: 600px; border: none; border-radius: 8px;"></iframe>


### PR DESCRIPTION
## Summary
- show Day 1 and 3 minigames in daily indexes so progress checks appear at the end of each day
- reorder Day 2 and 4 daily outlines so the final links lead to their minigames
- move mission checklist iframes to the last lesson for Days 6, 7, and 9

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: missing packages/types)*
- `npx quartz build` *(fails: unsupported node version)*

------
https://chatgpt.com/codex/tasks/task_e_689e305fcc04832b9a40bbee57cc9585