### PR TITLE
Remove prohibited terms from Robocode course

### DIFF
--- a/content/robocode/Day-11+/00_predictive_firing.md
+++ b/content/robocode/Day-11+/00_predictive_firing.md
@@ -23,4 +23,4 @@ bot.turnGunRightRadians(Utils.normalRelativeAngle(
 bot.fire(firePower);
 ```
 
-This simple approach predicts a straight-line path. Experiment with different `firePower` values to balance accuracy and energy.
+This basic approach predicts a straight-line path. Experiment with different `firePower` values to balance accuracy and energy.

--- a/content/robocode/Day-2/03_geometry.md
+++ b/content/robocode/Day-2/03_geometry.md
@@ -23,7 +23,7 @@ If the arena is 800 wide and 600 tall, the middle is at (400, 300).
 
 ---
 
-## 🔄 Turning Directions (Easy as Turning a Toy Car!)
+## 🔄 Turning Directions (As intuitive as turning a toy car!)
 
 Think of angles like spinning a spinner or turning your body. Angles are like direction numbers:
 

--- a/content/robocode/Day-3/index.md
+++ b/content/robocode/Day-3/index.md
@@ -17,7 +17,7 @@ tags:
 
 * Store information using Java variables
 * Choose the right datatype for robot state (ints, doubles, strings)
-* Use variables to control simple robot movements
+* Use variables to control basic robot movements
 
 > Ready to dive into **Day 3** 😎
 - [Variables and Datatypes](/robocode/Day-3/00_variables_and_datatypes)

--- a/content/robocode/Day-4/03_hit_by_bullet_event.md
+++ b/content/robocode/Day-4/03_hit_by_bullet_event.md
@@ -8,7 +8,7 @@ tags:
   - intermediate
 ---
 
-## 4 – Dodge When Hit (Super Simple)
+## 4 – Dodge When Hit (Direct Approach)
 
 When a bullet hits your robot, the `onHitByBullet` method runs.
 
@@ -48,7 +48,7 @@ double y = getY();
 
 …and use `getDirection()` to decide which way is safest.
 
-But for now, this two‑line dodge keeps things simple and fun.
+But for now, this two‑line dodge keeps things concise and fun.
 
 [Minigame](/robocode/Day-4/04_minigame)
 

--- a/content/robocode/Day-4/04_minigame.md
+++ b/content/robocode/Day-4/04_minigame.md
@@ -91,7 +91,7 @@ Your instructor will give you a file:
 
 - `PlayerBotLauncher.jar`
 
-Save this file somewhere easy to find, such as a folder on your Desktop. You can name the folder `PlayerBot`.
+Save this file somewhere convenient to find, such as a folder on your Desktop. You can name the folder `PlayerBot`.
 
 ---
 

--- a/content/robocode/Day-6/00_boolean_basics.md
+++ b/content/robocode/Day-6/00_boolean_basics.md
@@ -12,7 +12,7 @@ tags:
 
 # Understanding Booleans
 
-`boolean` values represent **true** or **false**. In Robocode you often use them to track simple on/off states.
+`boolean` values represent **true** or **false**. In Robocode you often use them to track basic on/off states.
 
 ```java
 boolean targetLocked = false;

--- a/content/robocode/Day-6/01_if_statements.md
+++ b/content/robocode/Day-6/01_if_statements.md
@@ -117,7 +117,7 @@ if (getGunHeat() == 0) {
 
 - Always start with the most **important** check first.
 - Use `{}` to group multiple lines of code.
-- Keep conditions simple and readable.
+- Keep conditions concise and readable.
 
 ---
 

--- a/content/robocode/Day-7/01_basic_debugging.md
+++ b/content/robocode/Day-7/01_basic_debugging.md
@@ -24,7 +24,7 @@ You will practice **testing and improving your robot** based on what you observe
 
 ## 🔧 Debugging Tools
 
-Use these simple tricks to track down bugs:
+Use these handy tricks to track down bugs:
 
 - Print messages using `System.out.println()` to see what your bot is doing.
 - Test your bot after _each small change_.

--- a/content/robocode/Day-7/index.md
+++ b/content/robocode/Day-7/index.md
@@ -18,7 +18,7 @@ tags:
 
 - Break robot behavior into reusable methods
 - Organize your code into classes for clarity
-- Adopt naming conventions for easy collaboration
+- Adopt naming conventions for smooth collaboration
 - Catch and handle runtime errors with `try/catch`
 - Practice step-by-step debugging in VS Code
 - Prevent crashes so your robot keeps fighting

--- a/content/robocode/Day-8/00_hit_reaction_plan.md
+++ b/content/robocode/Day-8/00_hit_reaction_plan.md
@@ -16,7 +16,7 @@ Before you write a single line of code, it helps to map out what your robot will
 
 ---
 
-# 🚦 Simple Event Flow – **Robocode Tank Royale** Bot
+# 🚦 Clear Event Flow – **Robocode Tank Royale** Bot
 
 This flowchart shows **what happens each game tick**. In Tank Royale the game engine automatically calls the three event methods *first*. If none of them fire, your `run()` code is the **fallback** that keeps your bot moving and scanning.
 
@@ -86,7 +86,7 @@ This flowchart shows **what happens each game tick**. In Tank Royale the game 
 
 ---
 
-✏️ **Your Task:** Copy this flow on paper, adjust the numbers (retreat distance, firepower, dodge angle) to your liking, and then mirror each box in your Java code. Visual planning keeps your bot’s logic clear and easy to debug!
+✏️ **Your Task:** Copy this flow on paper, adjust the numbers (retreat distance, firepower, dodge angle) to your liking, and then mirror each box in your Java code. Visual planning keeps your bot’s logic clear and straightforward to debug!
 
 
 ---

--- a/content/robocode/Day-8/01_survival_strategies.md
+++ b/content/robocode/Day-8/01_survival_strategies.md
@@ -19,7 +19,7 @@ Your goal in Robocode isn’t just to win with brute force — it’s to survive
 Here are some smart moves to stay alive longer:
 
 * **💡 Energy Awareness** – Fire smaller bullets (low power) when your energy is low. Don’t run out of juice while trying to get a knockout.
-* **🏃 Constant Motion** – Never stop moving. A stationary tank is an easy target.
+* **🏃 Constant Motion** – Never stop moving. A stationary tank is a vulnerable target.
 * **↪️ Perpendicular Turning** – When you're scanned or hit, turn 90° to the opponent. It helps you dodge future shots.
 * **🧱 Wall Smoothing** – Near the edges of the arena, curve your path slightly to avoid getting trapped.
 * **🎲 Random Dodge** – Mix up your movements with random speeds and turns so opponents can't predict you.

--- a/content/robocode/extras/exp_avg.md
+++ b/content/robocode/extras/exp_avg.md
@@ -15,7 +15,7 @@ tags:
 * In Robocode your radar sees an opponent robot at slightly different angles each tick (game step).
 * Those readings can jump around because the opponent moves or because of tiny measurement errors.
 * A jumpy red dot on your compass makes aiming messy – your turret might wiggle wildly.
-* **Exponential averaging** calms the dot down by blending the newest angle with the earlier average, giving you a smooth, easy‑to‑follow path.
+* **Exponential averaging** calms the dot down by blending the newest angle with the earlier average, giving you a smooth, clear path.
 
 ---
 

--- a/content/robocode/extras/vocab.md
+++ b/content/robocode/extras/vocab.md
@@ -279,7 +279,7 @@ Truncation is useful when you need the whole number part of a value and want to 
 
 ## 1.29 Primitive Data Types
 
-**Definition:** Basic data types built into Java that store simple values (not objects).
+**Definition:** Basic data types built into Java that store plain values (not objects).
 **Example:**
 
 ```java

--- a/content/robocode/index.md
+++ b/content/robocode/index.md
@@ -23,7 +23,7 @@ A gentle, supportive start for all learners. This week emphasizes **accessibilit
 Students will:
 
 - 💻 Set up Java and Robocode using multiple entry points
-- ✍️ Write simple programs with variables, loops, and conditions
+- ✍️ Write basic programs with variables, loops, and conditions
 - ⚙️ Build and move their first robot — safely and creatively
 - 📃 Practice `System.out.println` debugging as a reflection tool
 


### PR DESCRIPTION
## Summary
- Replace banned terms throughout Robocode lessons for consistent tone
- Revise headings and instructions to use alternative wording

## Testing
- `npm test`
- `npm run check` *(fails: Code style issues found in 99 files)*
- `node quartz/bootstrap-cli.mjs build` *(fails: CustomOgImages plugin fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e61ba4404832bab00bf16bc128eec