### PR TITLE
Document go() usage for queued Robocode movement commands

### DIFF
--- a/content/robocode/Day-11+/01_movement_patterns.md
+++ b/content/robocode/Day-11+/01_movement_patterns.md
@@ -8,7 +8,7 @@ tags:
   - intermediate
 ---
 
-The `set*` movement methods like `setTurnLeft`, `setTurnRight`, `setForward`, and `setBack` queue actions to run on the next turn. Call them from your `run()` loop or an event handler such as `onScannedRobot` so your bot can turn and move in the same tick.
+The `set*` movement methods like `setTurnLeft`, `setTurnRight`, `setForward`, and `setBack` queue actions to run on the next turn. Call them from your `run()` loop or an event handler such as `onScannedRobot`, then run `go()` to execute all queued commands so your bot can turn and move in the same tick.
 
 > Smart movement keeps your bot alive.
 
@@ -22,6 +22,7 @@ public void onScannedRobot(ScannedRobotEvent e) {
     } else {
         setBack(150);
     }
+    go(); // run queued commands
 }
 ```
 

--- a/content/robocode/extras/robocode_library.md
+++ b/content/robocode/extras/robocode_library.md
@@ -166,6 +166,7 @@ You were hit.
 @Override public void onHitByBullet(HitByBulletEvent e) {
     setBack(100);
     setTurnRight(45);
+    go(); // run queued commands
 }
 ```
 


### PR DESCRIPTION
## Summary
- mention that `go()` must be called after using `set*` movement methods in Robocode
- add `go()` call in `HitByBulletEvent` example in the library

## Testing
- `npm test`
- `npm run check` *(fails: Code style issues found in 99 files)*
- `node quartz/bootstrap-cli.mjs build` *(fails: Failed to emit from plugin `CustomOgImages`: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689f79ee3774832b9fe591f6ed8134c7