### PR TITLE
Add link to Minecraft controls for Sustainability Lab

### DIFF
--- a/content/sustainability_lab/index.md
+++ b/content/sustainability_lab/index.md
@@ -46,6 +46,7 @@ We believe learning should be inclusive, joyful, and co-created. Extra missions 
 Let’s build a future where kindness, creativity, and equity guide the game. 🌱
 
 [**How to join the server?**](/sustainability_lab/howtojoin)
+New to Minecraft? [**Learn the controls**](https://drive.google.com/file/d/1-N-r0Zrdqvdrg35f7n0fiSNLvPD8bNw0/view?usp=sharing)
 
 ## Look at what students have made in the past:
 <div class="padlet-embed" style="border:1px solid rgba(0,0,0,0.1);border-radius:2px;box-sizing:border-box;overflow:hidden;position:relative;width:100%;background:#F4F4F4"><p style="padding:0;margin:0"><iframe src="https://padlet.com/embed/3tk8anh7wnupcfj6" frameborder="0" allow="camera;microphone;geolocation;display-capture;clipboard-write" style="width:100%;height:608px;display:block;padding:0;margin:0"></iframe></p><div style="display:flex;align-items:center;justify-content:end;margin:0;height:28px"><a href="https://padlet.com?ref=embed" style="display:block;flex-grow:0;margin:0;border:none;padding:0;text-decoration:none" target="_blank"><div style="display:flex;align-items:center;"><img src="https://padlet.net/embeds/made_with_padlet_2022.png" width="114" height="28" style="padding:0;margin:0;background:0 0;border:none;box-shadow:none" alt="Made with Padlet"></div></a></div></div>


### PR DESCRIPTION
## Summary
- add link to Minecraft controls on Sustainability Lab landing page

## Testing
- `npm test`
- `npm run check` *(fails: Code style issues found in 99 files)*
- `npx quartz build` *(fails: Failed to emit from plugin `CustomOgImages`)*

------
https://chatgpt.com/codex/tasks/task_e_68a386d50724832bb8ec14889ec9704a