### PR TITLE
docs: add player card options for self-paced and instructor-led

### DIFF
--- a/content/robocode/Day-5/03_player_card.md
+++ b/content/robocode/Day-5/03_player_card.md
@@ -10,7 +10,10 @@ tags:
 
 > Showcase your robot by designing a personalized player card.
 
-Use the [player card generator](https://docs.google.com/forms/d/e/1FAIpQLSeO3NAcXqPCaacO21ZvApGUHdzv9Nuon2acvDtka6GBHQW6Hw/viewform?usp=header) to design your card.
+Choose the method that matches your course:
+
+- **Self-paced** learners: use the [player card generator website](https://axyl-casc.github.io/WikiMinigames/cardgen/).
+- **Instructor-led** courses: submit your details through the [player card Google Form](https://docs.google.com/forms/d/e/1FAIpQLSeO3NAcXqPCaacO21ZvApGUHdzv9Nuon2acvDtka6GBHQW6Hw/viewform?usp=header).
 
    <img src="/images/low/robocode/example_upload_forum.webp" alt="example_forum_upload" style="border-radius: 12px; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);">
 


### PR DESCRIPTION
## Summary
- outline player card submission options for self-paced and instructor-led classes

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: numerous missing modules and type errors)*
- `npx quartz build` *(fails: requires Node >=22, current v20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b43fe27c832bb503a0311c1aef52