### PR TITLE
Remove redundant body divider

### DIFF
--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -252,7 +252,6 @@ export function renderPage(
                 </div>
               </div>
               <Content {...componentData} />
-              <hr />
               <div class="page-footer">
                 {afterBody.map((BodyComponent) => (
                   <BodyComponent {...componentData} />


### PR DESCRIPTION
## Summary
- remove extra `<hr>` element from page body to avoid duplicate divider with footer

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: missing modules and types)*
- `npx quartz build` *(fails: unsupported engine node v20)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b6fdf150832bab1e5fe12e5bd8cf