### PR TITLE
feat: add home commands to choose disaster guide

### DIFF
--- a/content/sustainability_lab/Day-1/02_choose_disaster.md
+++ b/content/sustainability_lab/Day-1/02_choose_disaster.md
@@ -23,7 +23,7 @@ Your EARTH Knight’s story continues with a critical choice: **What kind of nat
 
 This choice sets the stage for Day 2 — where you’ll need to survive what you’ve imagined. Think like a storyteller and a city planner: What would your character fear? What would they prepare for?
 
-Pick a biome and safe spot to shelter, and make sure to record your `/tp` coordinates so you can return when the storm hits.
+Pick a biome and safe spot to shelter, then use `/sethome` to save it. When the storm hits, use `/home` to return quickly.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- update Day 1 disaster selection instructions to use `/sethome` and `/home`

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: missing modules)*
- `npx quartz build` *(fails: engine not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68ace281a2e8832b8f3ca0b82f157993